### PR TITLE
Remove install command for empty directory

### DIFF
--- a/j2735_convertor/CMakeLists.txt
+++ b/j2735_convertor/CMakeLists.txt
@@ -191,12 +191,6 @@ install(TARGETS j2735_convertor_node
 # )
 
 
-install(DIRECTORY
-        launch
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-        PATTERN ".svn" EXCLUDE
-        )
-
 #############
 ## Testing ##
 #############


### PR DESCRIPTION
Removed an unecessary "install" directive in the CMakeLists.txt that was preventing proper installation via `catkin_make install`.