### PR TITLE
Alternative fix for speed clipping in course plan

### DIFF
--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/CoarsePathNeighbors.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/CoarsePathNeighbors.java
@@ -130,9 +130,11 @@ public class CoarsePathNeighbors extends NeighborBase {
                 timeAtNext += (speedAtNext - curSpeed) / maxAccel_;
             }else {
                 // Only continuos accelerations are allowed so we will reduce our max accel in this case to reach top smooth speed at intersection
-                timeAtNext += (2.0 * (distToNext - lagDist)) / (curSpeed + operSpeed_);
+                //timeAtNext += (2.0 * (distToNext - lagDist)) / (curSpeed + operSpeed_);
                 // An alternative approach is to accelerate to operating speed before reaching the intersection.
                 // However, this can make the target distance un-achievable if the fine plan time steps do not line up with the inflection point when max speed is achieved. 
+                double cruiseTime = (distToNext - distToOperSpeed) / operSpeed_;
+                timeAtNext += timeToOperSpeed + cruiseTime;
             }
 
 
@@ -149,7 +151,9 @@ public class CoarsePathNeighbors extends NeighborBase {
                 } else { // We arrived at the light too early and need to slow down
                     double extraTime = timeBuffer_ - phaseTimeElapsed;
                     timeAtNext += extraTime;
-                    speedAtNext = 2.0*(distToNext - lagDist)/(timeAtNext - (curTime + lagTime_)) - curSpeed;
+                    if (speedAtNext < operSpeed_) {
+                        speedAtNext = 2.0*(distToNext - lagDist)/(timeAtNext - (curTime + lagTime_)) - curSpeed;
+                    }
                     state = phaseAtTime(intersectionIndex, timeAtNext); // Update state
                     validGreen = true;
                 }

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/FinePathNeighbors.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/FinePathNeighbors.java
@@ -107,6 +107,23 @@ public class FinePathNeighbors extends NeighborBase {
             } else {
                 log_.debug("PLAN", "Remove candidate speed due to signal violation: " + v);
             }
+
+            // If we can reach the speed limit add a extra node which gets us there as fast as possible
+            if (v >= speedLimit_) {
+                
+                double timeToLimit = (speedLimit_ - curSpeed) / maxAccel_;
+                deltaD = timeToLimit * (curSpeed + v) * 0.5;
+                newDist = curDist + deltaD;
+                double modifiedNewTime = curTime + timeToLimit; 
+                //System.out.println("Potential extra neighbor: " + new Node(newDist, modifiedNewTime, v));
+                if(!signalViolation(curDist, newDist, curTime, modifiedNewTime, v)) {
+
+                    neighbors.add(new Node(newDist, modifiedNewTime, v));
+                } else {
+                    log_.debug("PLAN", "Remove candidate speed due to signal violation: " + v);
+                }
+                
+            }
         }
         log_.debug("PLAN", "Generating neighbors of size " + neighbors.size());
 


### PR DESCRIPTION
This resolves the clipping of the max speed profile in the course plan, by having the fine plan add an additional node whenever it will reach the top speed. 