### PR TITLE
Fix/ead plan interpolation timestamps

### DIFF
--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ObjectCollisionChecker.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ObjectCollisionChecker.java
@@ -220,10 +220,13 @@ public class ObjectCollisionChecker implements INodeCollisionChecker {
    * The provided host plan will be interpolated using the provided IMotionInterpolator
    * 
    * @param hostPlan The host plan to set as the current plan
+   * @param startTime The time which planning is considered to have begun at. This is used for converting nodes to route locations
+	 * @param startDowntrack The downtrack distance where planning is considered to have begun at. This is used for converting nodes to route locations
+	 * 
    */
-  public void setHostPlan(List<Node> hostPlan) {
+  public void setHostPlan(List<Node> hostPlan, double startTime, double startDowntrack) {
     interpolatedHostPlan.set(motionInterpolator.interpolateMotion(hostPlan, distanceStep,
-      timeProvider.getCurrentTimeSeconds(), routeService.getCurrentDowntrackDistance()
+      startTime, startDowntrack
     ));
   }
 

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ObjectCollisionChecker.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ObjectCollisionChecker.java
@@ -222,7 +222,9 @@ public class ObjectCollisionChecker implements INodeCollisionChecker {
    * @param hostPlan The host plan to set as the current plan
    */
   public void setHostPlan(List<Node> hostPlan) {
-    interpolatedHostPlan.set(motionInterpolator.interpolateMotion(hostPlan, distanceStep));
+    interpolatedHostPlan.set(motionInterpolator.interpolateMotion(hostPlan, distanceStep,
+      timeProvider.getCurrentTimeSeconds(), routeService.getCurrentDowntrackDistance()
+    ));
   }
 
   /**
@@ -259,10 +261,12 @@ public class ObjectCollisionChecker implements INodeCollisionChecker {
   }
 
   @Override
-  public boolean hasCollision(List<Node> trajectory) {
+  public boolean hasCollision(List<Node> trajectory, double timeOffset, double distanceOffset) {
     
     // Convert the proposed trajectory to route points
-    List<RoutePointStamped> routePlan = motionInterpolator.interpolateMotion(trajectory, distanceStep);
+    List<RoutePointStamped> routePlan = motionInterpolator.interpolateMotion(trajectory, distanceStep,
+      timeOffset, distanceOffset
+    );
 
     return checkCollision(routePlan); // Check for collisions with tracked objects
 

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/TrafficSignalPlugin.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/TrafficSignalPlugin.java
@@ -828,10 +828,11 @@ public class TrafficSignalPlugin extends AbstractPlugin implements IStrategicPlu
         // CONVERT DATA ELEMENTS
         List<Node> eadResult = null;
         double speedLimit = pluginServiceLocator.getRouteService().getSpeedLimitAtLocation(traj.getStartLocation()).getLimit();
+        DataElementHolder state;
         // Try 3 times to plan. With updated state data each time if needed. We will accept the first completed plan
         for (int i = 0; i < 3; i++) {
             dtsb = computeDtsb();
-            DataElementHolder state = getCurrentStateData(speedLimit);
+            state = getCurrentStateData(speedLimit);
 
             log.info("Requesting AStar plan with intersections: " + intersections.toString());
 
@@ -849,6 +850,13 @@ public class TrafficSignalPlugin extends AbstractPlugin implements IStrategicPlu
         } else {
             log.info("Ead result is path of size: " + eadResult.size());
         }
+
+
+        // Set the new plan as the current plan for collision checker
+        DoubleDataElement startTime = (DoubleDataElement) state.get(DataElementKey.PLANNING_START_TIME);
+		DoubleDataElement startDowntrack = (DoubleDataElement) state.get(DataElementKey.PLANNING_START_DOWNTRACK);
+
+        collisionChecker.setHostPlan(eadResult, startTime.value(), startDowntrack.value());
 
         /*
          * Optimization has been decided against due to complexities in trajectory behavior.

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/TrafficSignalPlugin.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/TrafficSignalPlugin.java
@@ -828,7 +828,7 @@ public class TrafficSignalPlugin extends AbstractPlugin implements IStrategicPlu
         // CONVERT DATA ELEMENTS
         List<Node> eadResult = null;
         double speedLimit = pluginServiceLocator.getRouteService().getSpeedLimitAtLocation(traj.getStartLocation()).getLimit();
-        DataElementHolder state;
+        DataElementHolder state = new DataElementHolder();
         // Try 3 times to plan. With updated state data each time if needed. We will accept the first completed plan
         for (int i = 0; i < 3; i++) {
             dtsb = computeDtsb();

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/TrafficSignalPlugin.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/TrafficSignalPlugin.java
@@ -934,6 +934,8 @@ public class TrafficSignalPlugin extends AbstractPlugin implements IStrategicPlu
         DoubleDataElement operSpeedElem;
         DoubleDataElement vehicleLat;
         DoubleDataElement vehicleLon;
+        DoubleDataElement planningStartTime;
+        DoubleDataElement planningStartDowntrack;
         IntersectionCollectionDataElement icde;
 
         if (curVel.get() != null) {
@@ -958,6 +960,11 @@ public class TrafficSignalPlugin extends AbstractPlugin implements IStrategicPlu
         ic.intersections = convertIntersections(intersections);
         icde = new IntersectionCollectionDataElement(ic);
         state.put(DataElementKey.INTERSECTION_COLLECTION, icde);
+
+        planningStartTime = new DoubleDataElement(pluginServiceLocator.getTimeProvider().getCurrentTimeSeconds());
+        planningStartDowntrack = new DoubleDataElement(pluginServiceLocator.getRouteService().getCurrentDowntrackDistance());
+        state.put(DataElementKey.PLANNING_START_TIME, planningStartTime);
+        state.put(DataElementKey.PLANNING_START_DOWNTRACK, planningStartDowntrack);
 
         return state;
     }

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/appcommon/DataElementKey.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/appcommon/DataElementKey.java
@@ -45,5 +45,7 @@ public enum DataElementKey {
     SPAT_LIST,                      // list of SPAT messages captured
     SIGNAL_PHASE,
     SIGNAL_TIME_TO_NEXT_PHASE,      // seconds (double)
-    SIGNAL_TIME_TO_THIRD_PHASE      // seconds (double)
+    SIGNAL_TIME_TO_THIRD_PHASE,     // seconds (double)
+    PLANNING_START_TIME,            // seconds (double) 
+    PLANNING_START_DOWNTRACK        // seconds (double)
 }

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/EadAStar.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/EadAStar.java
@@ -111,9 +111,10 @@ public class EadAStar implements IEad {
      * the speed closest to our desired speed, and will return that as the goal node for detailed planning.
      *
      * This method only accounts for travel time, trying to minimize it without violating signal laws.
+     * Start time and downtrack distance are used for back calculating carma route positions and don't impact node states
      * @return a node representing the best goal we can hope to reach after the first intersection
      */
-    protected Node planCoarsePath(double operSpeed, Node start) throws Exception {
+    protected Node planCoarsePath(double operSpeed, Node start, double startTime, double startDowntrack) throws Exception {
 
         //we may be receiving spat signals from a farther intersection but haven't yet seen a MAP message from it,
         // so its rough distance is going to be a bogus, very large value; therefore, only look ahead for as many
@@ -153,7 +154,7 @@ public class EadAStar implements IEad {
         double exitTime = exitDist / operSpeed;
 
         //create a neighbor calculator for this tree using a coarse scale grid
-        coarseNeighborCalc_.initialize(intList_, numInt, coarseTimeInc_, coarseSpeedInc_, collisionChecker_);
+        coarseNeighborCalc_.initialize(intList_, numInt, coarseTimeInc_, coarseSpeedInc_, collisionChecker_, startTime, startDowntrack);
         coarseNeighborCalc_.setOperatingSpeed(operSpeed);
 
         //while no solution and we have not exceeded our cycle limit
@@ -202,16 +203,17 @@ public class EadAStar implements IEad {
     /**
      * Finds the best fine-grained path from current location to the far side of the nearest intersection
      * that minimizes fuel cost to reach the travel time goal.
+     * Start time and downtrack distance are used for back calculating carma route positions and don't impact node states
      * @param goal - the node beyond the nearest intersection that we are trying to reach
      * @return - the best path to the goal node
      * @apiNote neighbor nodes are located according to the increments in each dimension specified by the
      * config file parameters fineTimeInc, fineDistInc and fineSpeedInc.
      */
-    protected List<Node> planDetailedPath(Node start, Node goal) throws Exception {
+    protected List<Node> planDetailedPath(Node start, Node goal, double startTime, double startDowntrack) throws Exception {
         log_.debug("EAD", "Entering planDetailedPath with start = " + start.toString() + ", goal = " + goal.toString());
         
         //create a neighbor calculator for this tree using a detailed grid
-        fineNeighborCalc_.initialize(intList_, 1, fineTimeInc_, fineSpeedInc_, collisionChecker_);
+        fineNeighborCalc_.initialize(intList_, 1, fineTimeInc_, fineSpeedInc_, collisionChecker_, startTime, startDowntrack);
 
         //System.out.println("Goal: " + goal);
         //find the best path through this tree [use AStarSolver]
@@ -282,11 +284,13 @@ public class EadAStar implements IEad {
      * @param speed The current speed of the vehicle
      * @param operSpeed The target operating speed of the vehicle
      * @param intersections A sorted list of intersection data with the nearest intersections appearing earlier in the list
+     * @param startTime The time which planning is considered to have begun at. This is used for converting nodes to route locations
+     * @param startDowntrack The downtrack distance where planning is considered to have begun at. This is used for converting nodes to route locations
      * 
      * @return A list of node defining the planned vehicle trajectory
      */
     public List<Node> plan(double speed, double operSpeed, 
-        List<IntersectionData> intersections) throws Exception {
+        List<IntersectionData> intersections, double startTime, double startDowntrack) throws Exception {
 
         if (intersections == null  ||  intersections.size() == 0) {
             String msg = "plan invoked with a empty intersection list.";
@@ -317,11 +321,11 @@ public class EadAStar implements IEad {
         currentPath_ = null;
 
         //perform coarse planning to determine the goal node downtrack of the first intersection [planCoarsePath]
-        goal = planCoarsePath(operSpeed, startNode);
+        goal = planCoarsePath(operSpeed, startNode, startTime, startDowntrack);
 
         //build a detailed plan to reach the near-term goal node downtrack of first intersection [planDetailedPath]
         try {
-            currentPath_ = planDetailedPath(startNode, goal);
+            currentPath_ = planDetailedPath(startNode, goal, startTime, startDowntrack);
         }catch (Exception e) {
             log_.warn("EAD", "plan trapped exception from planDetailedPath: ", e);
             throw e;

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/EadAStar.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/EadAStar.java
@@ -289,6 +289,7 @@ public class EadAStar implements IEad {
      * 
      * @return A list of node defining the planned vehicle trajectory
      */
+    @Override
     public List<Node> plan(double speed, double operSpeed, 
         List<IntersectionData> intersections, double startTime, double startDowntrack) throws Exception {
 

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/IEad.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/IEad.java
@@ -45,9 +45,12 @@ public interface IEad {
 	 * @param speed The current speed of the vehicle
 	 * @param operSpeed The target operating speed of the vehicle
 	 * @param intersections A sorted list of intersection data with the nearest intersections appearing earlier in the list
+	 * @param startTime The time which planning is considered to have begun at. This is used for converting nodes to route locations
+	 * @param startDowntrack The downtrack distance where planning is considered to have begun at. This is used for converting nodes to route locations
 	 * 
 	 * @return A list of node defining the planned vehicle trajectory
 	 */
-	List<Node> plan(double speed, double operSpeed, List<IntersectionData> intersections) throws Exception;
+	List<Node> plan(double speed, double operSpeed, 
+		List<IntersectionData> intersections, double startTime, double startDowntrack) throws Exception;
 	
 }

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/IMotionInterpolator.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/IMotionInterpolator.java
@@ -38,8 +38,10 @@ public interface IMotionInterpolator {
    * 
    * @param path A time sorted list of nodes which define the host vehicle's desired trajectory
    * @param distanceStep The max distance gap between each point in the output list
+   * @param timeOffset A time offset which will be applied to the time of each input node
+   * @param distanceOffset A distance offset which will be applied to the distance of each input node
    * 
    * @return A list of route point stamped. The lanes and route segment values will not be set.
    */
-  public List<RoutePointStamped> interpolateMotion(List<Node> trajectory, double distanceStep);
+  public List<RoutePointStamped> interpolateMotion(List<Node> trajectory, double distanceStep, double timeOffset, double distanceOffset);
 }

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/INodeCollisionChecker.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/INodeCollisionChecker.java
@@ -31,8 +31,10 @@ public interface INodeCollisionChecker {
    * The collision check is only performed for adjacent nodes in the list. (n0 with n1) and (n1 with n2) NOT (n0 with n2)
    * 
    * @param trajectory A time sorted list of nodes which define the host vehicle's desired trajectory
+   * @param timeOffset A time offset which will be applied to the time of each input node
+   * @param distanceOffset A distance offset which will be applied to the distance of each input node
    * 
    * @return True if a collision was found between a pair of nodes in the list. False otherwise
    */
-  public boolean hasCollision(List<Node> trajectory);
+  public boolean hasCollision(List<Node> trajectory, double timeOffset, double distanceOffset);
 }

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/PlanInterpolator.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/PlanInterpolator.java
@@ -19,6 +19,7 @@ package gov.dot.fhwa.saxton.carma.signal_plugin.ead;
 import java.util.LinkedList;
 import java.util.List;
 
+import gov.dot.fhwa.saxton.carma.guidance.util.ITimeProvider;
 import gov.dot.fhwa.saxton.carma.guidance.util.trajectoryconverter.RoutePointStamped;
 import gov.dot.fhwa.saxton.carma.signal_plugin.ead.trajectorytree.Node;
 
@@ -31,7 +32,7 @@ import gov.dot.fhwa.saxton.carma.signal_plugin.ead.trajectorytree.Node;
 public class PlanInterpolator implements IMotionInterpolator {
 
   @Override
-  public List<RoutePointStamped> interpolateMotion(List<Node> trajectory, double distanceStep) {
+  public List<RoutePointStamped> interpolateMotion(List<Node> trajectory, double distanceStep, double timeOffset, double distanceOffset) {
     Node prevNode = null;
     List<RoutePointStamped> points = new LinkedList<>();
 
@@ -39,7 +40,7 @@ public class PlanInterpolator implements IMotionInterpolator {
     for (Node n: trajectory) {
       if (prevNode == null) {
 
-        points.add(new RoutePointStamped(n.getDistanceAsDouble(), 0, n.getTimeAsDouble())); // Add the first node to the list
+        points.add(new RoutePointStamped(n.getDistanceAsDouble() + distanceOffset, 0, n.getTimeAsDouble() + timeOffset)); // Add the first node to the list
         prevNode = n;
         continue;
       }
@@ -48,11 +49,11 @@ public class PlanInterpolator implements IMotionInterpolator {
       final double x_0 = prevNode.getDistanceAsDouble();
       final double v_0 = prevNode.getSpeedAsDouble();
 
-      final double t_f = n.getTimeAsDouble();
+      final double t_f = n.getTimeAsDouble() + distanceOffset;
       final double v_f = n.getSpeedAsDouble();
-      final double x_f = n.getDistanceAsDouble();
+      final double x_f = n.getDistanceAsDouble() + timeOffset;
 
-      final double dt =  t_f - t_0;
+      final double dt = t_f - t_0;
       final double dv = v_f - v_0;
       final double dx = x_f - x_0;
       

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/Trajectory.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/Trajectory.java
@@ -249,6 +249,20 @@ public class Trajectory implements ITrajectory {
 		}
 
 
+		DoubleDataElement startTime = (DoubleDataElement) stateData.get(DataElementKey.PLANNING_START_TIME);
+		DoubleDataElement startDowntrack = (DoubleDataElement) stateData.get(DataElementKey.PLANNING_START_DOWNTRACK);
+
+		if (startTime == null) {
+			startTime = new DoubleDataElement(0.0);
+			log_.error("TRAJ", "No start time provided. NCV handling will be incorrect");
+		}
+
+		if (startDowntrack == null) {
+			startDowntrack = new DoubleDataElement(0.0);
+			log_.error("TRAJ", "No start downtrack provided. NCV handling will be incorrect");
+		}
+
+
 		////////// UNDERSTAND THE INTERSECTION GEOMETRY & WHERE WE FIT IN
 
 
@@ -276,7 +290,7 @@ public class Trajectory implements ITrajectory {
 		//get speed command from EAD (assume it will handle position in stop box w/red light)
 		try {
 			log_.info("TrafficSignalPlugin", this.getSortedIntersections().toString());
-			path = ead_.plan(curSpeed_, operSpeed, this.getSortedIntersections());
+			path = ead_.plan(curSpeed_, operSpeed, this.getSortedIntersections(), startTime.value(), startDowntrack.value());
 		}catch (Exception e) {
 			log_.errorf("TRAJ", "Exception trapped by EAD algo: " + e.toString() +
 			"\n    Too many errors...rethrowing. " +

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/Trajectory.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/Trajectory.java
@@ -252,17 +252,6 @@ public class Trajectory implements ITrajectory {
 		DoubleDataElement startTime = (DoubleDataElement) stateData.get(DataElementKey.PLANNING_START_TIME);
 		DoubleDataElement startDowntrack = (DoubleDataElement) stateData.get(DataElementKey.PLANNING_START_DOWNTRACK);
 
-		if (startTime == null) {
-			startTime = new DoubleDataElement(0.0);
-			log_.error("TRAJ", "No start time provided. NCV handling will be incorrect");
-		}
-
-		if (startDowntrack == null) {
-			startDowntrack = new DoubleDataElement(0.0);
-			log_.error("TRAJ", "No start downtrack provided. NCV handling will be incorrect");
-		}
-
-
 		////////// UNDERSTAND THE INTERSECTION GEOMETRY & WHERE WE FIT IN
 
 

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/CoarsePathNeighbors.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/CoarsePathNeighbors.java
@@ -60,9 +60,9 @@ public class CoarsePathNeighbors extends NeighborBase {
 
     @Override
     public void initialize(List<IntersectionData> intersections, int numIntersections, double timeIncrement,
-                           double speedIncrement, INodeCollisionChecker collisionChecker) {
+                double speedIncrement, INodeCollisionChecker collisionChecker, double planningStartTime, double planningStartDowntrack) {
         log_.debug("EAD", "initialize called with timeInc = " + timeIncrement + ", speedInc = " + speedIncrement);
-        super.initialize(intersections, numIntersections, timeIncrement, speedIncrement, collisionChecker);
+        super.initialize(intersections, numIntersections, timeIncrement, speedIncrement, collisionChecker, planningStartTime, planningStartDowntrack);
     }
 
 

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/FinePathNeighbors.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/FinePathNeighbors.java
@@ -61,13 +61,13 @@ public class FinePathNeighbors extends NeighborBase {
 
     @Override
     public void initialize(List<IntersectionData> intersections, int numIntersections, double timeIncrement,
-                           double speedIncrement, INodeCollisionChecker collisionChecker) {
+                    double speedIncrement, INodeCollisionChecker collisionChecker, double planningStartTime, double planningStartDowntrack) {
 
         log_.info("EAD", "initialize called with timeInc = " + timeIncrement + ", speedInc = " + speedIncrement);
         // Set the acceptable stop distance to at least half the distance increment
         acceptableStopDist_ = Math.max(1.1 * 2.0 * timeIncrement * speedIncrement, acceptableStopDist_); 
         log_.info("EAD", "Using acceptable stop distance of: " + acceptableStopDist_);
-        super.initialize(intersections, numIntersections, timeIncrement, speedIncrement, collisionChecker);
+        super.initialize(intersections, numIntersections, timeIncrement, speedIncrement, collisionChecker, planningStartTime, planningStartDowntrack);
     }
 
     @Override

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/INeighborCalculator.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/INeighborCalculator.java
@@ -32,10 +32,12 @@ public interface INeighborCalculator {
    * @param numIntersections - the number of intersections to consider in this solution
    * @param timeIncrement - increment between adjacent time points in the grid, sec
    * @param speedIncrement - increment between adjacent speed points in the grid, m/s
- * @param collisionChecker_ 
+   * @param collisionChecker - Collision checker used for obstacle avoidance
+   * @param planningStartTime - The time which planning is considered to have begun at. This is used for converting nodes to route locations
+     @param planningStartDowntrack - The downtrack distance where planning is considered to have begun at. This is used for converting nodes to route locations
    */
   void initialize(List<IntersectionData> intersections, int numIntersections, double timeIncrement,
-                  double speedIncrement, INodeCollisionChecker collisionChecker_);
+                  double speedIncrement, INodeCollisionChecker collisionChecker, double planningStartTime, double planningStartDowntrack);
 
   /**
    * Gets a list of neighbors to the provided node

--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/NeighborBase.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/trajectorytree/NeighborBase.java
@@ -62,18 +62,23 @@ public abstract class NeighborBase implements INeighborCalculator {
 
     protected INodeCollisionChecker         collisionChecker_;
 
+    protected double                        planningStartTime_; // Starting planning time in seconds.
+    protected double                        planningStartDowntrack_; // Starting planning downtrack distance 
+
     /**
      * This will only be called when we are on the map of an intersection, so input intersections is
      * guaranteed to have at least one member.  They will be ordered from nearest to farthest.
      */
     @Override
     public void initialize(List<IntersectionData> intersections, int numIntersections, double timeIncrement,
-                           double speedIncrement, INodeCollisionChecker collisionChecker) {
+                           double speedIncrement, INodeCollisionChecker collisionChecker, double planningStartTime, double planningStartDowntrack) {
         intersections_ = intersections;
         numInt_ = numIntersections;
         timeInc_ = timeIncrement;
         speedInc_ = speedIncrement;
         collisionChecker_ = collisionChecker;
+        planningStartTime_ = planningStartTime;
+        planningStartDowntrack_ = planningStartDowntrack;
 
         //This method will be called each time the EAD model replans, which will happen each time a visible signal
         // changes phases. This is an opportunity to learn more about its cycle timing, so grab whatever info is there.
@@ -256,6 +261,6 @@ public abstract class NeighborBase implements INeighborCalculator {
      * @return true if collision detected
      */
     protected boolean hasConflict(Node startNode, Node endNode) {
-        return this.collisionChecker_.hasCollision(Arrays.asList(startNode, endNode));
+        return this.collisionChecker_.hasCollision(Arrays.asList(startNode, endNode), planningStartTime_, planningStartDowntrack_);
     }
 }


### PR DESCRIPTION
Adds the planning start time and start distance as offsets for nodes when comparing to roadway obstables for collision checks in TrafficSignalPlugin