### PR TITLE
Fix dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,6 @@
 # if they change
 
 .cache
-circle.yml
-README.md
 
 **/*.class
 *.bak


### PR DESCRIPTION
Dockerignore was not copying README.md and circle.yml which was causing Git to report local changes when generating a version number (e.g. tagging it as a SNAPSHOT(2) build) even on a clean checkout.