### PR TITLE
Fix/refactor conflict manager

### DIFF
--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/CartesianObject.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/CartesianObject.java
@@ -16,6 +16,7 @@
 
 package gov.dot.fhwa.saxton.carma.geometry.cartesian;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import org.ros.rosjava_geometry.Transform;
@@ -265,5 +266,10 @@ public class CartesianObject implements CartesianElement {
 
   @Override public int getNumDimensions() {
     return numDimensions;
+  }
+
+  @Override public String toString() {
+    double[][] minMaxArray = getMinMaxCoordinates();
+    return this.getClass().getSimpleName() + " {" +"min " + Arrays.toString(minMaxArray[0]) + ", max " + Arrays.toString(minMaxArray[1]) + "}";
   }
 }

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/ISpatialStructure.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/ISpatialStructure.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap;
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
 
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.CartesianObject;
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.Point;

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/ISpatialStructureFactory.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/ISpatialStructureFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
+
+/**
+ * Factory pattern class for the construction of SpatialStructure instances.
+ * <p>
+ */
+public interface ISpatialStructureFactory {
+    /**
+     * Build a ISpatialStructure
+     * <p>
+     * 
+     * The returned ISpatialStructure is not guaranteed to be thread safe
+     */
+    public NSpatialHashMap buildSpatialStructure();
+}

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashKey.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashKey.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap;
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
 
 import java.util.Arrays;
 

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMap.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMap.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap;
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
 
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.CartesianObject;
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.IIntersectionChecker;

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMapFactory.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMapFactory.java
@@ -21,21 +21,22 @@ import java.util.HashMap;
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.AxisAlignedBoundingBox;
 
 /**
- * Factory/builder pattern class for the construction of NSpatialHashMap instances.
+ * Factory pattern class for the construction of NSpatialHashMap instances.
  * <p>
  * Assigns the strategies needed by the NSpatialHashMap instance.
  */
-public class NSpatialHashMapFactory {
+public class NSpatialHashMapFactory implements ISpatialStructureFactory{
+    public final double[] cellDims;
     /**
-     * Build a NSpatialHashMap with the default configuration.
-     * <p>
-     * {@link SimpleHashStrategy} is used to hash objects
-     * {@link AxisAlignedBoundingBox} is used for collision detection
-     * {@link HashMap} is used for the underlying data structure
+     * Constructor
      * 
-     * The returned map is not thread safe on its own
+     * @param cellDims The dimensions of a cell which this will map points to
      */
-    public static NSpatialHashMap buildSpatialHashMap(double[] cellDims) {
+    public NSpatialHashMapFactory(double[] cellDims) {
+        this.cellDims = cellDims;
+    }
+    @Override
+    public NSpatialHashMap buildSpatialStructure() {
         return new NSpatialHashMap(new AxisAlignedBoundingBox(), new SimpleHashStrategy(cellDims), new HashMap<>());
     }
 }

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMapFactory.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMapFactory.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap;
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
 
 import java.util.HashMap;
 

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashStrategy.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashStrategy.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap;
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
 
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.Point;
 

--- a/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/SimpleHashStrategy.java
+++ b/carmajava/geometry/src/main/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/SimpleHashStrategy.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap;
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
 
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.Point;
 

--- a/carmajava/geometry/src/test/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialhashmap/NSpatialHashMapTest.java
+++ b/carmajava/geometry/src/test/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialhashmap/NSpatialHashMapTest.java
@@ -14,12 +14,12 @@
  * the License.
  */
 
-package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap;
+package gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure;
 
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.*;
-import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap.NSpatialHashMap;
-import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap.NSpatialHashStrategy;
-import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialhashmap.SimpleHashStrategy;
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.NSpatialHashMap;
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.NSpatialHashStrategy;
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.SimpleHashStrategy;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/carmajava/geometry/src/test/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMapTest.java
+++ b/carmajava/geometry/src/test/java/gov/dot/fhwa/saxton/carma/geometry/cartesian/spatialstructure/NSpatialHashMapTest.java
@@ -58,7 +58,8 @@ public class NSpatialHashMapTest {
   public void testInsert() throws Exception {
     // Test 2D
     double[] cellSizes = {2,2};
-    NSpatialHashMap map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes);
+    NSpatialHashMapFactory factory = new NSpatialHashMapFactory(cellSizes);
+    NSpatialHashMap map = factory.buildSpatialStructure();
 
     // Test 2D Object
     List<? extends Point> points = new LinkedList<>(Arrays.asList(
@@ -115,7 +116,8 @@ public class NSpatialHashMapTest {
     assertEquals(2, cellsWithObject);
 
     // Test single point object inserts to the same key as that point
-    map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes); // Reset map
+    factory = new NSpatialHashMapFactory(cellSizes);
+    map = factory.buildSpatialStructure(); // Reset map
     points = new LinkedList<>(Arrays.asList(
       new Point2D(4,4)
     ));
@@ -128,7 +130,8 @@ public class NSpatialHashMapTest {
 
     // Test 3D object that fits within a cell
     cellSizes = new double[]{2,2,2};
-    map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes); // Reset map
+    factory = new NSpatialHashMapFactory(cellSizes);
+    map = factory.buildSpatialStructure(); // Reset map
 
     points = new LinkedList<>(Arrays.asList(
       new Point3D(4.5,4.5,4.5),
@@ -161,7 +164,8 @@ public class NSpatialHashMapTest {
   public void testGetCollisionsWithPoint() throws Exception {
     // Test 2D
     double[] cellSizes = {1,1};
-    NSpatialHashMap map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes);
+    NSpatialHashMapFactory factory = new NSpatialHashMapFactory(cellSizes);
+    NSpatialHashMap map = factory.buildSpatialStructure();
 
 
     // Test No Intersect 2D Objects and Point
@@ -189,7 +193,9 @@ public class NSpatialHashMapTest {
 
     // Test No Intersect 3D
     cellSizes = new double[]{1,1,1};
-    map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes); // Reset map
+    factory = new NSpatialHashMapFactory(cellSizes);
+    map = factory.buildSpatialStructure(); // Reset map
+
     points = new LinkedList<>(Arrays.asList(
       new Point3D(1,0, 7),
       new Point3D(4,0, 8),
@@ -208,7 +214,9 @@ public class NSpatialHashMapTest {
 
     // Test No Intersect nd
     cellSizes = new double[]{1,1,1,1,1};
-    map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes); // Reset map
+    factory = new NSpatialHashMapFactory(cellSizes);
+    map = factory.buildSpatialStructure(); // Reset map
+
     points = new LinkedList<>(Arrays.asList(
       new Point(1, 0, 7, 5, 3),
       new Point(4, 0, 6, 7, 5),
@@ -238,7 +246,8 @@ public class NSpatialHashMapTest {
     // Test 2D
     double[] cellSizes = {1,1};
     IIntersectionChecker aabbChecker = new AxisAlignedBoundingBox();
-    NSpatialHashMap map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes);
+    NSpatialHashMapFactory factory = new NSpatialHashMapFactory(cellSizes);
+    NSpatialHashMap map = factory.buildSpatialStructure();
 
 
     // Test No Intersect 2D
@@ -289,7 +298,8 @@ public class NSpatialHashMapTest {
     ));
     obj2 = new CartesianObject(points2);
 
-    map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes); // Reset map
+    factory = new NSpatialHashMapFactory(cellSizes);
+    map = factory.buildSpatialStructure(); // Reset map
     map.insert(obj);
 
     collidingObjects = map.getCollisions(obj2);
@@ -321,7 +331,8 @@ public class NSpatialHashMapTest {
 
     // Test No Intersect 3D
     cellSizes = new double[]{1,1,1};
-    map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes); // Reset map
+    factory = new NSpatialHashMapFactory(cellSizes);
+    map = factory.buildSpatialStructure(); // Reset map
 
     points = new LinkedList<>(Arrays.asList(
       new Point3D(1,0, 7),
@@ -352,7 +363,8 @@ public class NSpatialHashMapTest {
 
     // Test No Intersect nd
     cellSizes = new double[]{1,1,1,1,1};
-    map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes); // Reset map
+    factory = new NSpatialHashMapFactory(cellSizes);
+    map = factory.buildSpatialStructure(); // Reset map
 
     points = new LinkedList<>(Arrays.asList(
       new Point(1, 0, 7, 5, 3),
@@ -402,8 +414,9 @@ public class NSpatialHashMapTest {
     // Test 2D
     double[] cellSizes = {2,2};
     IIntersectionChecker aabbChecker = new AxisAlignedBoundingBox();
-    NSpatialHashMap map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes);
-
+    NSpatialHashMapFactory factory = new NSpatialHashMapFactory(cellSizes);
+    NSpatialHashMap map = factory.buildSpatialStructure();
+    
     // Test Removing object
     List<? extends Point> points = new LinkedList<>(Arrays.asList(
       new Point2D(4,4),
@@ -448,7 +461,8 @@ public class NSpatialHashMapTest {
     // Test 2D
     double[] cellSizes = {2,2};
     IIntersectionChecker aabbChecker = new AxisAlignedBoundingBox();
-    NSpatialHashMap map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes);
+    NSpatialHashMapFactory factory = new NSpatialHashMapFactory(cellSizes);
+    NSpatialHashMap map = factory.buildSpatialStructure();
 
     List<? extends Point> points = new LinkedList<>(Arrays.asList(
       new Point2D(0,2),
@@ -482,7 +496,8 @@ public class NSpatialHashMapTest {
     // Test 2D
     double[] cellSizes = {2,2};
     IIntersectionChecker aabbChecker = new AxisAlignedBoundingBox();
-    NSpatialHashMap map = NSpatialHashMapFactory.buildSpatialHashMap(cellSizes);
+    NSpatialHashMapFactory factory = new NSpatialHashMapFactory(cellSizes);
+    NSpatialHashMap map = factory.buildSpatialStructure();
 
     assertNull(map.getBounds());
 

--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/GuidanceMain.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/GuidanceMain.java
@@ -16,6 +16,7 @@
 
 package gov.dot.fhwa.saxton.carma.guidance;
 
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.NSpatialHashMapFactory;
 import gov.dot.fhwa.saxton.carma.guidance.arbitrator.Arbitrator;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.ConflictManager;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.IMobilityTimeProvider;
@@ -212,7 +213,7 @@ public class GuidanceMain extends SaxtonBaseNode {
     // Set time strategy
     IMobilityTimeProvider timeProvider = new SystemUTCTimeProvider();
     // Build conflict manager
-    conflictManager = new ConflictManager(cellSize, downtrackMargin, crosstrackMargin, timeMargin, lateralBias,
+    conflictManager = new ConflictManager(new NSpatialHashMapFactory(cellSize), downtrackMargin, crosstrackMargin, timeMargin, lateralBias,
     longitudinalBias, temporalBias, timeProvider);
   }
 

--- a/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/conflictdetector/ConflictManagerTest.java
+++ b/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/conflictdetector/ConflictManagerTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.*;
 import gov.dot.fhwa.saxton.carma.geometry.GeodesicCartesianConverter;
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.Point;
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.Point3D;
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.NSpatialHashMapFactory;
 import gov.dot.fhwa.saxton.carma.geometry.geodesic.Location;
 import gov.dot.fhwa.saxton.carma.guidance.maneuvers.FutureLateralManeuver;
 import gov.dot.fhwa.saxton.carma.guidance.maneuvers.IManeuver;
@@ -90,7 +91,7 @@ public class ConflictManagerTest {
     double timeMargin = 0.05;
     MockTimeProvider timeProvider = new MockTimeProvider();
     timeProvider.setCurrentTime(0.0);
-    ConflictManager cm = new ConflictManager(cellSize, downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(cellSize), downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
     cm.setRoute(route);
     // Build path
     List<RoutePointStamped> path = new ArrayList<>();
@@ -113,7 +114,7 @@ public class ConflictManagerTest {
     double timeMargin = 0.5;
     MockTimeProvider timeProvider = new MockTimeProvider();
     timeProvider.setCurrentTime(0.0);
-    ConflictManager cm = new ConflictManager(cellSize, downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(cellSize), downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
     cm.setRoute(route);
     // Build path
     List<RoutePointStamped> path = new ArrayList<>();
@@ -170,7 +171,7 @@ public class ConflictManagerTest {
     double timeMargin = 0.5;
     MockTimeProvider timeProvider = new MockTimeProvider();
     timeProvider.setCurrentTime(0.0);
-    ConflictManager cm = new ConflictManager(cellSize, downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(cellSize), downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
     cm.setRoute(route);
     // Build path
     List<RoutePointStamped> path = new ArrayList<>();
@@ -229,7 +230,7 @@ public class ConflictManagerTest {
     double timeMargin = 0.5;
     MockTimeProvider timeProvider = new MockTimeProvider();
     timeProvider.setCurrentTime(0.0);
-    ConflictManager cm = new ConflictManager(cellSize, downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(cellSize), downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
     cm.setRoute(route);
     //// Test conflict with same path
     // Build path
@@ -528,7 +529,7 @@ public class ConflictManagerTest {
     double timeMargin = 0.5;
     MockTimeProvider timeProvider = new MockTimeProvider();
     timeProvider.setCurrentTime(0.0);
-    ConflictManager cm = new ConflictManager(cellSize, downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(cellSize), downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
     cm.setRoute(route);
     //// Test conflict with same path
     // Build path
@@ -734,7 +735,7 @@ public class ConflictManagerTest {
     double timeMargin = 0.5;
     MockTimeProvider timeProvider = new MockTimeProvider();
     timeProvider.setCurrentTime(0.0);
-    ConflictManager cm = new ConflictManager(cellSize, downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(cellSize), downtrackMargin, crosstrackMargin, timeMargin, 0.0, 0.0, 0.0, timeProvider);
     cm.setRoute(route);
     //// Test conflict with same path
     // Build path

--- a/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/util/trajectoryconverter/TrajectoryConverterTest.java
+++ b/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/util/trajectoryconverter/TrajectoryConverterTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.*;
 import gov.dot.fhwa.saxton.carma.geometry.GeodesicCartesianConverter;
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.Point;
 import gov.dot.fhwa.saxton.carma.geometry.cartesian.Point3D;
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.NSpatialHashMapFactory;
 import gov.dot.fhwa.saxton.carma.geometry.geodesic.Location;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.ConflictManager;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.IMobilityTimeProvider;
@@ -183,7 +184,7 @@ public class TrajectoryConverterTest {
     when(timeProvider.getCurrentTimeMillis()).thenReturn(0L);
     when(timeProvider.getCurrentTimeSeconds()).thenReturn(0.0);
     double[] cellSize = {5.0,2.5,0.15};
-    ConflictManager cm = new ConflictManager(cellSize, 2.5, 1.0, 0.05, 0.0, 0.0, 0.0, timeProvider);
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(cellSize), 2.5, 1.0, 0.05, 0.0, 0.0, 0.0, timeProvider);
     cm.setRoute(route);
     // Call function
     List<RoutePointStamped> tempPoints = tc.convertToPath(traj, 0, 0, 0, 0, 0, 0);

--- a/carmajava/guidance_plugin_api/src/main/java/gov/dot/fhwa/saxton/carma/guidance/conflictdetector/IConflictDetector.java
+++ b/carmajava/guidance_plugin_api/src/main/java/gov/dot/fhwa/saxton/carma/guidance/conflictdetector/IConflictDetector.java
@@ -18,6 +18,7 @@ package gov.dot.fhwa.saxton.carma.guidance.conflictdetector;
 
 import java.util.List;
 
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.ISpatialStructure;
 import gov.dot.fhwa.saxton.carma.guidance.util.trajectoryconverter.RoutePointStamped;
 
 /**
@@ -53,6 +54,7 @@ public interface IConflictDetector {
    * 
    * @param hostPath The path representing the host trajectory
    * @param otherPath The path to find conflicts with by comparing against the host trajectory
+   * @param spatialStructure The spatial structure which will store objects and provide collision checking capability
    * @param downtrackMargin The margin around a RoutePointStamped in the downtrack dimension in which a collision will be considered to have occurred
    * @param crosstrackMargin The margin around a RoutePointStamped in the crosstrack dimension in which a collision will be considered to have occurred
    * @param timeMargin The margin around a RoutePointStamped in the time dimension in which a collision will be considered to have occurred
@@ -62,6 +64,6 @@ public interface IConflictDetector {
    * 
    * @return A sorted list of conflict spaces where the two paths conflict
    */
-  public List<ConflictSpace> getConflicts(List<RoutePointStamped> hostPath, List<RoutePointStamped> otherPath, 
+  public List<ConflictSpace> getConflicts(List<RoutePointStamped> hostPath, List<RoutePointStamped> otherPath, ISpatialStructure spatialStructure,
     double downtrackMargin, double crosstrackMargin, double timeMargin, double longitudinalBias, double lateralBias, double temporalBias);
 }

--- a/carmajava/launch/params/GuidanceParams.yaml
+++ b/carmajava/launch/params/GuidanceParams.yaml
@@ -172,7 +172,6 @@ acc_vehicle_front_frame_id: 'vehicle_front'
 # Note: This string must match the Versionable.getVersionInfo().componentName() value of the plugin
 default_mobility_conflict_handler: 'Yield Plugin'
 
-
 # Double: The size of a the downtrack dimension of a cell in the collision systems spatial hash map
 # Units: meters
 # Dimension should be larger than 1 car length

--- a/carmajava/launch/params/GuidanceParams.yaml
+++ b/carmajava/launch/params/GuidanceParams.yaml
@@ -173,21 +173,20 @@ acc_vehicle_front_frame_id: 'vehicle_front'
 default_mobility_conflict_handler: 'Yield Plugin'
 
 
-# TODO reset these values to 10, 6, .2 
 # Double: The size of a the downtrack dimension of a cell in the collision systems spatial hash map
 # Units: meters
 # Dimension should be larger than 1 car length
-conflict_map_cell_downtrack_size: 20.0
+conflict_map_cell_downtrack_size: 10.0
 
 # Double: The size of a the crosstrack dimension of a cell in the collision systems spatial hash map
 # Units: meters
 # Dimension should be larger than 1 car width
-conflict_map_cell_crosstrack_size: 15.0
+conflict_map_cell_crosstrack_size: 6.0
 
 # Double: The size of a the time dimension of a cell in the collision systems spatial hash map
 # Units: seconds
 # Dimension should be larger than one timestep in a MobilityPath
-conflict_map_cell_time_size: 1.5
+conflict_map_cell_time_size: 0.2
 
 # Double: The margin around a MobilityPath point
 # in the downtrack dimension in which a collision will be considered to have occured

--- a/carmajava/launch/params/SignalParams.yaml
+++ b/carmajava/launch/params/SignalParams.yaml
@@ -211,6 +211,21 @@ ead/NCVHandling/objectMotionPredictorModel: "SIMPLE_LINEAR_REGRESSION"
 # Units: ms 
 ead/NCVHandling/collision/maxObjectHistoricalDataAge: 3000
 
+# Double: The size of a the downtrack dimension of a cell in the collision systems spatial hash map
+# Units: meters
+# Dimension should be larger than 1 car length
+ead/NCVHandling/collision/cell_downtrack_size: 20.0
+
+# Double: The size of a the crosstrack dimension of a cell in the collision systems spatial hash map
+# Units: meters
+# Dimension should be larger than 1 car width
+ead/NCVHandling/collision/cell_crosstrack_size: 15.0
+
+# Double: The size of a the time dimension of a cell in the collision systems spatial hash map
+# Units: seconds
+# Dimension should be larger than one timestep in a MobilityPath
+ead/NCVHandling/collision/cell_time_size: 2.0
+
 # Double: The maximum distance between points in the interpolated vehicle path used for collision checking
 # Units: m
 ead/NCVHandling/collision/distanceStep: 2.5

--- a/carmajava/signal_plugin/src/test/java/gov/dot/fhwa/saxton/carma/signal_plugin/EADAStarPlanTest.java
+++ b/carmajava/signal_plugin/src/test/java/gov/dot/fhwa/saxton/carma/signal_plugin/EADAStarPlanTest.java
@@ -19,6 +19,7 @@ import org.ros.message.MessageFactory;
 import org.ros.message.Time;
 import org.ros.node.NodeConfiguration;
 
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.NSpatialHashMapFactory;
 import gov.dot.fhwa.saxton.carma.guidance.ArbitratorService;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.ConflictManager;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.IConflictDetector;
@@ -370,8 +371,8 @@ public class EADAStarPlanTest {
         
             // Create conflict manager using default guidance settings
         
-            // There may be a bug in ConflictManager or hash map because setting cell size for time to 3 makse the planning fail
-            ConflictManager cm = new ConflictManager(new double[] {20.0, 15.0, 1.5}, 5.0, 1.2, 0.1, // USE THESE VALUES
+            // There may be a bug in ConflictManager or hash map because setting cell size for time to 3 makes the planning fail
+            ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(new double[] {20.0, 15.0, 2.0}), 5.0, 1.2, 0.1, // USE THESE VALUES
             0.0, -0.25, 0.0, mobilityTimeProvider);
         
             cm.setRoute(route);
@@ -396,6 +397,9 @@ public class EADAStarPlanTest {
             when(ps.getDouble("~ead/NCVHandling/collision/longitudinalBias")).thenReturn(0.0);
             when(ps.getDouble("~ead/NCVHandling/collision/lateralBias")).thenReturn(0.0);
             when(ps.getDouble("~ead/NCVHandling/collision/temporalBias")).thenReturn(0.0);
+            when(ps.getDouble("~ead/NCVHandling/collision/cell_downtrack_size")).thenReturn(20.0);
+            when(ps.getDouble("~ead/NCVHandling/collision/cell_crosstrack_size")).thenReturn(15.0);
+            when(ps.getDouble("~ead/NCVHandling/collision/cell_time_size")).thenReturn(2.0);
 
             ObjectCollisionChecker occ = new ObjectCollisionChecker(psl, motionPredictorFactory, planInterpolator);
 

--- a/carmajava/signal_plugin/src/test/java/gov/dot/fhwa/saxton/carma/signal_plugin/ObjectCollisionCheckerTest.java
+++ b/carmajava/signal_plugin/src/test/java/gov/dot/fhwa/saxton/carma/signal_plugin/ObjectCollisionCheckerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import gov.dot.fhwa.saxton.carma.geometry.cartesian.spatialstructure.NSpatialHashMapFactory;
 import gov.dot.fhwa.saxton.carma.guidance.ArbitratorService;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.ConflictManager;
 import gov.dot.fhwa.saxton.carma.guidance.conflictdetector.IMobilityTimeProvider;
@@ -105,7 +106,7 @@ public class ObjectCollisionCheckerTest {
 
     // Create conflict manager using default guidance settings
 
-    ConflictManager cm = new ConflictManager(new double[] {10.0, 6.0, 0.2}, 5.0, 1.2, 0.1,
+    ConflictManager cm = new ConflictManager(new NSpatialHashMapFactory(new double[] {20.0, 15.0, 2.0}), 5.0, 1.2, 0.1,
       0.0, -0.25, 0.0, mobilityTimeProvider);
 
     cm.setRoute(route);
@@ -126,6 +127,9 @@ public class ObjectCollisionCheckerTest {
     when(ps.getDouble("~ead/NCVHandling/collision/longitudinalBias")).thenReturn(0.0);
     when(ps.getDouble("~ead/NCVHandling/collision/lateralBias")).thenReturn(0.0);
     when(ps.getDouble("~ead/NCVHandling/collision/temporalBias")).thenReturn(0.0);
+    when(ps.getDouble("~ead/NCVHandling/collision/cell_downtrack_size")).thenReturn(20.0);
+    when(ps.getDouble("~ead/NCVHandling/collision/cell_crosstrack_size")).thenReturn(15.0);
+    when(ps.getDouble("~ead/NCVHandling/collision/cell_time_size")).thenReturn(2.0);
 
     ObjectCollisionChecker occ = new ObjectCollisionChecker(psl, motionPredictorFactory, planInterpolator);
 


### PR DESCRIPTION
Fixes #55  ; refs #54

Addresses Issue 55 by refactoring the conflict manager system in guidance to support dependency injection of different collision checking structure objects. This allows a plugin or other guidance component to use it's own parameters for collision checking while still levering the logic in ConflictManager

Changes proposed in this pull request:
* Create an ISpatialStructureFactory for making different collision checking structures
* Refactor ConflictManager.java to use the ISpatialStructureFactory and ISpatialStructure interface instead of the NSpatialHashMap directly. Different ISpatialStructure objects can then be injected
* Rename spatialhashmap package to spatialstructure package to better reflect its purpose.
* Fix all unit tests based on api changes
* Update toString method in CartesianObject to be more verbose
* Update Traffic Signal Plugin to support this change

@qswawrq 
