### PR TITLE
Resolve NaN values coming out of the plan interpolator

### DIFF
--- a/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/PlanInterpolator.java
+++ b/carmajava/signal_plugin/src/main/java/gov/dot/fhwa/saxton/carma/signal_plugin/ead/PlanInterpolator.java
@@ -84,15 +84,26 @@ public class PlanInterpolator implements IMotionInterpolator {
         }
 
       } else {
-        v = Math.sqrt(v_old * v_old + two_a_x);
+        double v_f_sqr = v_old * v_old + two_a_x;
+        if (v_f_sqr <= 0.0) {
+          v = 0.0;
+        } else {
+          v = Math.sqrt(v_f_sqr);
+        }
         t = t_0 + (v - v_old) / a; // With constant acceleration
 
         // Interpolate between current node and previous node
         while (x < x_f) {
 
           points.add(new RoutePointStamped(x, 0, t)); // Add previous node and the new interpolated nodes to list
+
           v_old = v;
-          v = Math.sqrt(v_old * v_old + two_a_x);
+          v_f_sqr = v_old * v_old + two_a_x;
+          if (v_f_sqr <= 0.0) {
+            v = 0.0;
+          } else {
+            v = Math.sqrt(v_f_sqr);
+          }
           t += (v - v_old) / a;
           x += distanceStep;
         }

--- a/carmajava/signal_plugin/src/test/java/gov/dot/fhwa/saxton/carma/signal_plugin/PlanInterpolatorTest.java
+++ b/carmajava/signal_plugin/src/test/java/gov/dot/fhwa/saxton/carma/signal_plugin/PlanInterpolatorTest.java
@@ -40,6 +40,7 @@ import sensor_msgs.NavSatFix;
 import sensor_msgs.NavSatStatus;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import gov.dot.fhwa.saxton.carma.signal_plugin.ead.trajectorytree.Node;
 
@@ -135,6 +136,31 @@ public class PlanInterpolatorTest {
     assertTrue(routePointAlmostEqual(new RoutePointStamped(15.0, 0.0, 1.0), points.get(points.size() - 1), 0.0001)); // Include last node
     assertEquals(3, points.size());
     assertTrue(routePointAlmostEqual(new RoutePointStamped(12.75, 0.0, 0.55), points.get(1), 0.0001));
+  }
+
+  /**
+   * Tests if the interpolation between two nodes can generate an NaN value
+   * @throws Exception
+   */
+  @Test
+  public void testNaNEdgeCase() throws Exception {
+    PlanInterpolator planInterpolator = new PlanInterpolator();
+
+
+    // Empty list will return empty list
+    List<RoutePointStamped> points = planInterpolator.interpolateMotion(new ArrayList<Node>(), 0.2, 0, 0);
+    assertTrue(points.isEmpty());
+
+    // A single node will return a single point
+    Node n1 = new Node(0.0, 0.0, 2.0);
+    Node n2 = new Node(84.0, 64.0, 0.0);
+    points = planInterpolator.interpolateMotion(Arrays.asList(n1,n2), 2.5, 0, 0);
+
+    for (RoutePointStamped p: points) {
+      assertFalse(Double.isNaN(p.getDowntrack()));
+      assertFalse(Double.isNaN(p.getCrosstrack()));
+      assertFalse(Double.isNaN(p.getStamp()));
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #59 ; 
 This resolves Issue 59 by checking if the new velocity value crosses 0. If it does the value will be capped at 0 rather than the square root being taken

The following check is added in two places to prevent the issue
```
        double v_f_sqr = v_old * v_old + two_a_x;
        if (v_f_sqr <= 0.0) {
          v = 0.0;
        } else {
          v = Math.sqrt(v_f_sqr);
        }
```

Additionally, a unit test was created to replicate the issue and prove out the fix. 

Changes proposed in this pull request:
* Prevent negative velocities resulting in NaN values

@qswawrq 
