### PR TITLE
Fix duplicate application of standoff distance when calculating ACC gap

### DIFF
--- a/carmajava/guidance_plugin_api/src/main/java/gov/dot/fhwa/saxton/carma/guidance/maneuvers/BasicAccStrategy.java
+++ b/carmajava/guidance_plugin_api/src/main/java/gov/dot/fhwa/saxton/carma/guidance/maneuvers/BasicAccStrategy.java
@@ -60,9 +60,9 @@ public class BasicAccStrategy extends AbstractAccStrategy {
   }
 
   @Override
-  public boolean evaluateAccTriggerConditions(double distToFrontVehicle, double currentSpeed,
+  public boolean evaluateAccTriggerConditions(double distGap, double currentSpeed,
       double frontVehicleSpeed) {
-    return computeActualTimeGap(distGap(distToFrontVehicle), currentSpeed, frontVehicleSpeed) < desiredTimeGap;
+    return computeActualTimeGap(distGap, currentSpeed, frontVehicleSpeed) < desiredTimeGap;
   }
 
   @Override
@@ -95,7 +95,7 @@ public class BasicAccStrategy extends AbstractAccStrategy {
       double rawSpeedCmd = speedCmdSignal.get().getData() + currentSpeed;
       speedCmd = rawSpeedCmd;
       //speedCmd = applyAccelLimit(rawSpeedCmd, currentSpeed, maxAccel);
-      log.info(String.format(
+      log.debug(String.format(
           "ACC OVERRIDE CMD = %.02f, current speed = %.02f, override after accel limit applied (%.02f m/s/s) = %.02f, distToVehicle: %.02f m",
           rawSpeedCmd, currentSpeed, maxAccel, speedCmd, distToFrontVehicle));
       speedCmd = Math.min(speedCmd, desiredSpeedCommand);

--- a/carmajava/guidance_plugin_api/src/main/java/gov/dot/fhwa/saxton/carma/guidance/maneuvers/IAccStrategy.java
+++ b/carmajava/guidance_plugin_api/src/main/java/gov/dot/fhwa/saxton/carma/guidance/maneuvers/IAccStrategy.java
@@ -51,7 +51,7 @@ public interface IAccStrategy {
   /**
    * Evaluate whether or not ACC would activate given the input conditions
    * 
-   * @param distToFrontVehicle Distance, in meters, to the vehicle directly in front of the current vehicle.
+   * @param distGap Distance, in meters, to the vehicle directly in front of the current vehicle minus the desired standoff distance
    * Use NO_FRONT_VEHICLE_DISTANCE if no such vehicle is detected.
    * @param currentSpeed The current vehicles speed, in meters per second,
    * @param frontVehicleSpeed The front vehicle's speed, in meters per second. Use NO_FRONT_VEHICLE_SPEED if there


### PR DESCRIPTION
# PR Details
Resolves Issue #86. 
## Description

Issue number 86 was caused by the standoff distance being applied twice in the evaluateAccTriggerConditions function. This made it possible to both trigger ACC and exit ACC in a single iteration of  computeAccOverrideSpeed. This change removes the extra application of standoff distance to the calculated timegap

## Related Issue

#86 

## Motivation and Context

Improve ACC performance to help improve Traffic Signal Plugin NCV handling behavior

## How Has This Been Tested?

Ran the Traffic Signal Plugin with the change behind and NCV as described by the issue reproduction instructions. After change was applied, the incorrect behavior was no longer observed. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
