### PR TITLE
Convert transform math to C++ and move from Roadway to Sensor Fusion

### DIFF
--- a/sensor_fusion/CMakeLists.txt
+++ b/sensor_fusion/CMakeLists.txt
@@ -59,9 +59,21 @@ include_directories(
 
 file(GLOB_RECURSE headers */*.hpp */*.h)
 
-add_executable(${PROJECT_NAME}_node ${headers} src/main.cpp src/sensor_fusion.cpp src/wgs84_utils.cpp)
+add_executable(${PROJECT_NAME}_node ${headers} src/main.cpp src/sensor_fusion.cpp)
 add_dependencies( ${PROJECT_NAME}_node ${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
+
+add_library(wgs84_utils_library src/wgs84_utils.cpp)
+add_dependencies(wgs84_utils_library ${catkin_EXPORTED_TARGETS})
+
+add_library(transform_maintainer_library src/transform_maintainer.cpp)
+add_dependencies( transform_maintainer_library ${catkin_EXPORTED_TARGETS})
+target_link_libraries( transform_maintainer_library
+  wgs84_utils_library
+)
+
 target_link_libraries(${PROJECT_NAME}_node
+        wgs84_utils_library
+        transform_maintainer_library
         ${catkin_LIBRARIES}
         ${Boost_LIBRARIES}
         )
@@ -86,7 +98,7 @@ endif(${BUILD_TEST_INTERFACE_MANAGER})
 #############
 
 ## Mark executables and/or libraries for installation
- install(TARGETS ${PROJECT_NAME}_node
+ install(TARGETS ${PROJECT_NAME}_node wgs84_utils_library transform_maintainer_library
    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -105,4 +117,19 @@ install(DIRECTORY
         cfg
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
         PATTERN ".svn" EXCLUDE
+        )
+
+
+##########
+## Test ##
+##########
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+catkin_add_gtest(transform_maintainer_test tests/transform_maintainer_test.cpp)
+
+target_link_libraries( transform_maintainer_test
+        wgs84_utils_library
+        transform_maintainer_library
+        ${Boost_LIBRARIES} 
+        ${catkin_LIBRARIES}
         )

--- a/sensor_fusion/src/sensor_fusion.cpp
+++ b/sensor_fusion/src/sensor_fusion.cpp
@@ -690,7 +690,7 @@ void SensorFusionApplication::process_bsm(const cav_msgs::BSMConstPtr &msg) {
     // All tf2 multiplication works as expected with matrix on right applied to matrix on left to do multiplication
     ROS_DEBUG_STREAM_NAMED("bsm_logger","bsm_coord_rad (lat,lon,elev,heading): (" << bsm_coord_rad.lat << ", " << bsm_coord_rad.lon << ", " << bsm_coord_rad.elevation << ", " << bsm_coord_rad.heading << ")");
     // Get bsm position in nef frame
-    tf2::Vector3 bsm_in_map_trans = wgs84_utils::geodesic_2_cartesian(bsm_coord_rad, ecef_in_ned_tf);
+    tf2::Vector3 bsm_in_map_trans = wgs84_utils::geodesic_to_ecef(bsm_coord_rad, ecef_in_ned_tf);
     // Apply heading as orientation
     const tf2::Vector3 z_axis(0,0,1);
     tf2::Quaternion rot_in_ned(z_axis, bsm_coord_rad.heading);
@@ -754,7 +754,6 @@ void SensorFusionApplication::process_bsm(const cav_msgs::BSMConstPtr &msg) {
     ros::serialization::OStream stream(back.src_data[src_id].get() + sizeof(uint32_t), serial_size);
     ros::serialization::serialize(stream, obj);
     tracker_->addObjects(objects.begin(), objects.end(),src_id, obj.header.stamp.toBoost());
-    //bsm_obj_ = obj; //TODO used to bypass fusion
 }
 
 void SensorFusionApplication::velocity_cb(const ros::MessageEvent<geometry_msgs::TwistStamped> &event) 

--- a/sensor_fusion/src/sensor_fusion.cpp
+++ b/sensor_fusion/src/sensor_fusion.cpp
@@ -35,6 +35,7 @@
 #include "sensor_fusion.h"
 #include "wgs84_utils.h"
 #include "timer.h"
+#include "transform_maintainer.h"
 #include <cav_msgs/ConnectedVehicleList.h>
 
 #include <cav_srvs/GetDriversWithCapabilities.h>
@@ -75,7 +76,7 @@ namespace torc
 
 class SimTimer : public cav::Timer
 {
-    virtual boost::posix_time::ptime getTime() override 
+    virtual boost::posix_time::ptime getTime() override
     {
         return ros::Time::now().toBoost();
     }
@@ -198,7 +199,7 @@ TrackedObject toTrackedObject(const cav_msgs::ExternalObject& obj)
 }
 } // End torc namespace
 
-int SensorFusionApplication::run() 
+int SensorFusionApplication::run()
 {
     nh_.reset(new ros::NodeHandle());
     pnh_.reset(new ros::NodeHandle("~"));
@@ -208,8 +209,19 @@ int SensorFusionApplication::run()
     pnh_->param<std::string>("inertial_frame_name", inertial_frame_name_, "odom");
     pnh_->param<std::string>("body_frame_name", body_frame_name_, "base_link");
     pnh_->param<std::string>("ned_frame_name", ned_frame_name_, "ned");
-    pnh_->param<bool>("use_interface_mgr", use_interface_mgr_, true);
+    pnh_->param<std::string>("earth_frame_name", earth_frame_name_, "earth");
+    pnh_->param<std::string>("global_pos_sensor_frame_name", global_pos_sensor_frame_name_, "pinpoint");
+    pnh_->param<std::string>("local_pos_sensor_frame_name", local_pos_sensor_frame_name_, "pinpoint");
+    pnh_->param<bool>("use_interface_mgr", use_interface_mgr_, false);
 
+    // Setup transform maintainer
+    tf2_broadcaster_.reset(new tf2_ros::TransformBroadcaster());
+    tf_maintainer_.init(&tf2_buffer_, &(*tf2_broadcaster_),
+     &odom_map_, &navsatfix_map_, &heading_map_,
+     earth_frame_name_, ned_frame_name_, inertial_frame_name_, 
+     body_frame_name_, global_pos_sensor_frame_name_, local_pos_sensor_frame_name_);
+
+    // Use sim time if needed
     bool use_sim_time;
     nh_->param<bool>("/use_sim_time", use_sim_time, false);
 
@@ -244,8 +256,8 @@ int SensorFusionApplication::run()
         dyn_cfg_server_->setCallback(f);
     }
 
-    ros::Subscriber bsm_sub = nh_->subscribe<cav_msgs::BSM>("bsm", 1000, &SensorFusionApplication::bsm_cb, this);
-
+    ros::Subscriber bsm_sub = nh_->subscribe<cav_msgs::BSM>("bsm", 50, &SensorFusionApplication::bsm_map_cb, this);
+    
     if(use_interface_mgr_)
     {
         ROS_INFO_STREAM("Waiting for Interface Manager");
@@ -253,9 +265,9 @@ int SensorFusionApplication::run()
         update_services_timer_ = nh_->createTimer(ros::Duration(5.0), [this](const ros::TimerEvent& ev){ update_subscribed_services(); }, false, true);
         ROS_INFO_STREAM("Interface Manager available");
     }
-	else
+		else
     {
-		//This allows us to manually set the topics to listen, rather than querying the interface manager. Topics can be set through a xaml list in the launch file
+		    //This allows us to manually set the topics to listen, rather than querying the interface manager. Topics can be set through a xaml list in the launch file
 				
         // Odometry
         {
@@ -327,8 +339,33 @@ int SensorFusionApplication::run()
     ros::Rate r(20);
     while(ros::ok())
     {
-        ros::spinOnce();
+        // Process callbacks
+        ros::spinOnce(); // spinOnce tries to process all the elements in every subscriber queue at the moment it is called. 
 
+        // Can we get them processed afterword just like objects
+
+        // Updates transforms with new data.
+        // If we got a new nav sat fix but not a new heading should we wait for the new heading?
+        // TODO only update the transforms if new data is provided
+        if (!odom_map_.empty())
+            tf_maintainer_.odometry_update_cb(odom_map_.begin()->second); // Always update odometry first
+        if (!navsatfix_map_.empty() && !heading_map_.empty() && navsatfix_map_.begin()->second->header.seq != last_nav_sat_seq) {
+            tf_maintainer_.nav_sat_fix_update_cb(navsatfix_map_.begin()->second, heading_map_.begin()->second);
+            last_nav_sat_seq = navsatfix_map_.begin()->second->header.seq;
+        }
+
+        // After updating transforms we should process bsm objects
+        ROS_DEBUG_STREAM("BSM Id map of size: " << bsm_id_map_.size());
+        for (std::pair<std::string, cav_msgs::BSMConstPtr> el : bsm_id_map_)
+        {
+            process_bsm(el.second);
+        }
+
+        // Clear the bsm map. It will be rebuilt on the next call to spinOnce.
+        bsm_id_map_.clear();
+
+
+        // After updating transforms we should process the sensor objects
         while(!objects_cb_q_.empty())
         {
             objects_cb(objects_cb_q_.front().second,objects_cb_q_.front().first);
@@ -345,12 +382,12 @@ int SensorFusionApplication::run()
 void SensorFusionApplication::update_subscribed_services() 
 {
     ROS_INFO_STREAM("Updating subscribed services");
-
+    
     // Odometry
     std::vector<std::string> ret = get_api("position/odometry");
     for(const std::string& it : ret)
     {
-        if(sub_map_.find(it) == sub_map_.end())
+        if(sub_map_.find(it) == sub_map_.end()) 
         {
             sub_map_[it] = nh_->subscribe<nav_msgs::Odometry>(it, 1, [this](const ros::MessageEvent<nav_msgs::Odometry const>& msg){ odom_cb(msg); });
         }
@@ -360,7 +397,7 @@ void SensorFusionApplication::update_subscribed_services()
     ret = get_api("position/nav_sat_fix");
     for(const std::string& it : ret)
     {
-        if(sub_map_.find(it) == sub_map_.end())
+        if(sub_map_.find(it) == sub_map_.end()) 
         {
             sub_map_[it] = nh_->subscribe<sensor_msgs::NavSatFix>(it, 1, [this](const ros::MessageEvent<sensor_msgs::NavSatFix const>&msg){ navsatfix_cb(msg); });
         }
@@ -370,7 +407,7 @@ void SensorFusionApplication::update_subscribed_services()
     ret = get_api("position/heading");
     for(const std::string& it : ret)
     {
-        if(sub_map_.find(it) == sub_map_.end())
+        if(sub_map_.find(it) == sub_map_.end()) 
         {
             sub_map_[it] = nh_->subscribe<cav_msgs::HeadingStamped>(it, 1, [this](const ros::MessageEvent<cav_msgs::HeadingStamped>&  msg){ heading_cb(msg); });
         }
@@ -390,7 +427,7 @@ void SensorFusionApplication::update_subscribed_services()
     ret = get_api("sensor/objects");
     for(const std::string& it : ret)
     {
-        if(sub_map_.find(it) == sub_map_.end())
+        if(sub_map_.find(it) == sub_map_.end()) 
         {
             sub_map_[it] = nh_->subscribe<cav_msgs::ExternalObjectList>(it, 1, [this, it](const cav_msgs::ExternalObjectListConstPtr& msg){ objects_cb_q_.push_back(std::make_pair(it, msg)); });
         }
@@ -409,8 +446,8 @@ std::vector<std::string> SensorFusionApplication::get_api(const std::string &nam
 
     if(client.exists() && client.call(srv))
     {
-	    ROS_INFO_STREAM("get_drivers_with_capabilities returned: " << srv.response);
-
+        ROS_INFO_STREAM("get_drivers_with_capabilities returned: " << srv.response);
+        
         // The service returns a list of drivers that have the api we provided
         for(std::string fqn : srv.response.driver_data)
         {
@@ -418,7 +455,7 @@ std::vector<std::string> SensorFusionApplication::get_api(const std::string &nam
             std::string driverName = fqn.substr(0, pos);
 
             // If we haven't subscribed to the topic formed by the name of the node and the service add this topic to the return list
-            if(sub_map_.find(fqn) == sub_map_.end())
+            if(sub_map_.find(fqn) == sub_map_.end()) 
             {
                 ret.push_back(fqn);
             }
@@ -584,9 +621,33 @@ void SensorFusionApplication::objects_cb(const cav_msgs::ExternalObjectListConst
     tracker_->addObjects(transformed_list.begin(), transformed_list.end(), hash, transformStamped.header.stamp.toBoost());
 }
 
-void SensorFusionApplication::bsm_cb(const cav_msgs::BSMConstPtr &msg) 
-{
-    ROS_DEBUG_STREAM_NAMED("bsm_logger", "Received bsm message: " << msg);
+inline std::string bsmIdFromBuffer(std::vector<uint8_t> id_buffer) {
+
+    if (id_buffer.size() != 4) {
+        // TODO throw exception
+        return "";
+    }
+
+    std::stringstream stream;
+    for (int i = 0; i < id_buffer.size(); i++) {
+        stream << std::setfill ('0') << std::setw(2) << std::hex << id_buffer[i];
+    }
+
+    return stream.str();
+
+}
+
+void SensorFusionApplication::bsm_map_cb(const cav_msgs::BSMConstPtr &msg) {
+
+    ROS_INFO_NAMED("bsm_logger","PROCESSING BSM");
+    std::string bsm_id = bsmIdFromBuffer(msg->core_data.id);
+    ROS_INFO_STREAM_NAMED("bsm_logger","BSM_ID: " << bsm_id);
+    bsm_id_map_[bsm_id] = msg;
+}
+
+// TODO investigate BSM fusion further. There may be extra bugs introduced by merge
+void SensorFusionApplication::process_bsm(const cav_msgs::BSMConstPtr &msg) {
+    ROS_DEBUG_STREAM_NAMED("bsm_logger","Received bsm message: " << msg);
     if(heading_map_.empty() || navsatfix_map_.empty())
     {
         ROS_DEBUG_STREAM_NAMED("bsm_logger", "Received bsm before heading and navsatfix updated unable to process msg");
@@ -594,22 +655,23 @@ void SensorFusionApplication::bsm_cb(const cav_msgs::BSMConstPtr &msg)
     }
     auto hash = std::hash<std::string>();
     size_t src_id = hash("bsm_objects");
-    cav_msgs::ExternalObject obj;
-    obj.header.frame_id = inertial_frame_name_;
-    obj.header.stamp = msg->header.stamp;
-    obj.presence_vector = 0;
 
-    geometry_msgs::TransformStamped odom_tf, ned_odom_tf;
-    try 
-    {
-        odom_tf = tf2_buffer_.lookupTransform(inertial_frame_name_, body_frame_name_, msg->header.stamp);
-        ned_odom_tf = tf2_buffer_.lookupTransform(ned_frame_name_, inertial_frame_name_, msg->header.stamp);
-    } 
-    catch (tf2::TransformException&ex) 
-    {
-        ROS_WARN_STREAM(ex.what());
+    tf2::Stamped<tf2::Transform> ecef_in_ned_tf, odom_in_map_tf;
+    try {
+
+        odom_in_map_tf = tf_maintainer_.get_transform(ned_frame_name_, inertial_frame_name_, msg->header.stamp, true);
+        ecef_in_ned_tf = tf_maintainer_.get_transform(ned_frame_name_, "earth", msg->header.stamp, true);
+
+    } catch (tf2::TransformException&ex) {
+        ROS_WARN_STREAM_NAMED("bsm_logger", "Sensor fusion transform lookup exception: " << ex.what());
         return;
     }
+
+    cav_msgs::ExternalObject obj;
+    obj.header.frame_id = inertial_frame_name_;
+    obj.header.stamp = odom_in_map_tf.stamp_; // Use the timestamp of the transform for this bsm to ensure it can be converted
+    obj.presence_vector = 0;
+
 
     obj.presence_vector |= cav_msgs::ExternalObject::ID_PRESENCE_VECTOR;
     obj.id = (msg->core_data.id[0] << 24) | (msg->core_data.id[1] << 16) | (msg->core_data.id[2] << 8) | (msg->core_data.id[3]);
@@ -618,37 +680,32 @@ void SensorFusionApplication::bsm_cb(const cav_msgs::BSMConstPtr &msg)
     obj.bsm_id.resize(msg->core_data.id.size());
     std::copy(msg->core_data.id.begin(), msg->core_data.id.end(), obj.bsm_id.begin());
 
-    wgs84_utils::wgs84_coordinate bsm_coord;
-    bsm_coord.heading   = msg->core_data.heading;
-    bsm_coord.elevation = msg->core_data.elev;
-    bsm_coord.lat       = msg->core_data.latitude;
-    bsm_coord.lon       = msg->core_data.longitude;
+    wgs84_utils::wgs84_coordinate bsm_coord_rad;
+    bsm_coord_rad.heading   = msg->core_data.heading * wgs84_utils::DEG2RAD;
+    bsm_coord_rad.elevation = msg->core_data.elev;
+    bsm_coord_rad.lat       = msg->core_data.latitude * wgs84_utils::DEG2RAD;
+    bsm_coord_rad.lon       = msg->core_data.longitude * wgs84_utils::DEG2RAD;
 
-    wgs84_utils::wgs84_coordinate ref_wgs84;
-    ref_wgs84.heading   = heading_map_.begin()->second->heading;
-    ref_wgs84.elevation = navsatfix_map_.begin()->second->altitude;
-    ref_wgs84.lat       = navsatfix_map_.begin()->second->latitude;
-    ref_wgs84.lon       = navsatfix_map_.begin()->second->longitude;
+   
+    // All tf2 multiplication works as expected with matrix on right applied to matrix on left to do multiplication
+    ROS_DEBUG_STREAM_NAMED("bsm_logger","bsm_coord_rad (lat,lon,elev,heading): (" << bsm_coord_rad.lat << ", " << bsm_coord_rad.lon << ", " << bsm_coord_rad.elevation << ", " << bsm_coord_rad.heading << ")");
+    // Get bsm position in nef frame
+    tf2::Vector3 bsm_in_map_trans = wgs84_utils::geodesic_2_cartesian(bsm_coord_rad, ecef_in_ned_tf);
+    // Apply heading as orientation
+    const tf2::Vector3 z_axis(0,0,1);
+    tf2::Quaternion rot_in_ned(z_axis, bsm_coord_rad.heading);
+    // BSM transform in map
+    tf2::Transform bsm_in_map_tf(rot_in_ned, bsm_in_map_trans);
+    
 
-    Eigen::Vector3d odom_pose;
-    odom_pose[0] = odom_tf.transform.translation.x;
-    odom_pose[1] = odom_tf.transform.translation.y;
-    odom_pose[2] = odom_tf.transform.translation.z;
-
-    Eigen::Quaterniond odom_rot;
-    odom_rot.x() = odom_tf.transform.rotation.x;
-    odom_rot.y() = odom_tf.transform.rotation.y;
-    odom_rot.z() = odom_tf.transform.rotation.z;
-    odom_rot.w() = odom_tf.transform.rotation.w;
-
-    Eigen::Transform<double, 3, Eigen::Affine> ned_odom_tf_eig;
-    ned_odom_tf_eig = Eigen::Translation3d(ned_odom_tf.transform.translation.x, ned_odom_tf.transform.translation.y, ned_odom_tf.transform.translation.z)
-        * Eigen::Quaterniond(ned_odom_tf.transform.rotation.w, ned_odom_tf.transform.rotation.x, ned_odom_tf.transform.rotation.y, ned_odom_tf.transform.rotation.z);
-
-    Eigen::Quaterniond out_rot;
-    Eigen::Vector3d out_pose;
-
-    wgs84_utils::convertToOdom(bsm_coord, ref_wgs84, odom_pose, odom_rot, ned_odom_tf_eig, out_pose, out_rot);
+    tf2::Transform bsm_in_odom = odom_in_map_tf.inverse() * bsm_in_map_tf;
+    tf2::Vector3 bsm_trans = bsm_in_odom.getOrigin();
+    tf2::Quaternion bsm_rot = bsm_in_odom.getRotation();
+    
+    
+    Eigen::Vector3d out_pose(bsm_trans.getX(), bsm_trans.getY(), bsm_trans.getZ());
+    
+    Eigen::Quaterniond out_rot(bsm_rot.getW(), bsm_rot.getX(), bsm_rot.getY(), bsm_rot.getZ()); // Quaturniond is a quaturnion with double values
 
     obj.presence_vector |= cav_msgs::ExternalObject::POSE_PRESENCE_VECTOR;
 
@@ -668,7 +725,7 @@ void SensorFusionApplication::bsm_cb(const cav_msgs::BSMConstPtr &msg)
       velocity_vector[1] = 0.0;
       velocity_vector[2] = 0.0;
       
-      velocity_vector = out_rot.inverse().toRotationMatrix() * velocity_vector;
+      velocity_vector = out_rot.toRotationMatrix() * velocity_vector;
       
       obj.presence_vector |= cav_msgs::ExternalObject::VELOCITY_PRESENCE_VECTOR;
       obj.velocity.twist.linear.x = velocity_vector[0];
@@ -680,11 +737,13 @@ void SensorFusionApplication::bsm_cb(const cav_msgs::BSMConstPtr &msg)
     obj.confidence = 1.0;
 
     obj.presence_vector |= cav_msgs::ExternalObject::SIZE_PRESENCE_VECTOR;
-    obj.size.x = msg->core_data.size.vehicle_length;
+    // TODO double check these size values
+    obj.size.x = msg->core_data.size.vehicle_length / 2;
     obj.size.y = msg->core_data.size.vehicle_width / 2;
-    obj.size.z = 1.5;
+    obj.size.z = 1.5; // TODO probably worth picking a picking a big z value
     ROS_DEBUG_STREAM_NAMED("bsm_logger", "Converted bsm message: " << obj);
 
+    //TODO uncomment this is where fusion occurs
     std::vector<torc::TrackedObject> objects;
     objects.push_back(torc::toTrackedObject(obj));
     torc::TrackedObject& back = objects.back();
@@ -694,7 +753,8 @@ void SensorFusionApplication::bsm_cb(const cav_msgs::BSMConstPtr &msg)
     memcpy(back.src_data[src_id].get(),&serial_size,sizeof(uint32_t));
     ros::serialization::OStream stream(back.src_data[src_id].get() + sizeof(uint32_t), serial_size);
     ros::serialization::serialize(stream, obj);
-    tracker_->addObjects(objects.begin(), objects.end(), src_id, msg->header.stamp.toBoost());
+    tracker_->addObjects(objects.begin(), objects.end(),src_id, obj.header.stamp.toBoost());
+    //bsm_obj_ = obj; //TODO used to bypass fusion
 }
 
 void SensorFusionApplication::velocity_cb(const ros::MessageEvent<geometry_msgs::TwistStamped> &event) 
@@ -705,19 +765,19 @@ void SensorFusionApplication::velocity_cb(const ros::MessageEvent<geometry_msgs:
 }
 
 void SensorFusionApplication::heading_cb(const ros::MessageEvent<cav_msgs::HeadingStamped> &event) 
-{
+{    
     std::string name = event.getPublisherName();
     heading_map_[name] = event.getMessage();
 }
 
 void SensorFusionApplication::navsatfix_cb(const ros::MessageEvent<sensor_msgs::NavSatFix> &event) 
-{
+{    
     std::string name = event.getPublisherName();
     navsatfix_map_[name] = event.getMessage();
 }
 
 void SensorFusionApplication::odom_cb(const ros::MessageEvent<nav_msgs::Odometry> &event) 
-{
+{    
     std::string name = event.getPublisherName();
     odom_map_[name] = event.getMessage();
 }

--- a/sensor_fusion/src/sensor_fusion.h
+++ b/sensor_fusion/src/sensor_fusion.h
@@ -67,6 +67,7 @@
 #include <unordered_map>
 #include <memory>
 #include <array>
+#include <limits>
 
 
 
@@ -128,9 +129,7 @@ private:
     std::string inertial_frame_name_, body_frame_name_, ned_frame_name_,
       earth_frame_name_, global_pos_sensor_frame_name_, local_pos_sensor_frame_name_;
 
-    cav_msgs::ExternalObject bsm_obj_;
-
-    long unsigned int last_nav_sat_seq = -1;
+    unsigned long last_nav_sat_seq = std::numeric_limits<unsigned long>::max();
 
     /**
      * @brief This function is the bond call back for on_broken event

--- a/sensor_fusion/src/transform_maintainer.cpp
+++ b/sensor_fusion/src/transform_maintainer.cpp
@@ -18,30 +18,19 @@
 
 void TransformMaintainer::nav_sat_fix_update_cb(const sensor_msgs::NavSatFixConstPtr host_veh_loc, const cav_msgs::HeadingStampedConstPtr heading_msg)
 {
-    // TODO
-    // // Assign the new host vehicle location
-    // if (navsatfix_map_->empty() || heading_map_->empty()) {
-    //   std::string msg = "TransformMaintainer nav_sat_fix_update_cb called before heading and nav_sat_fix received";
-    //   ROS_WARN_STREAM("TRANSFORM | " << msg);
-    //   return; // If we don't have a heading and a nav sat fix the map->odom transform cannot be calculated
-    // }
-    // sensor_msgs::NavSatFixConstPtr host_veh_loc = navsatfix_map_->begin()->second;
     
     // These values must be time synched
     if (host_veh_loc->header.stamp != heading_msg->header.stamp) {
-      // TODO return or something
       ROS_WARN_STREAM("TRANSFORM | Tried to update transforms without synched heading and nav_sat_fix");
       return;
     }
 
     if (last_nav_sat_stamp >= host_veh_loc->header.stamp) {
-      // TODO return or something
       ROS_WARN_STREAM("TRANSFORM | Old nav sat received prev: " << last_nav_sat_stamp << " update: " << host_veh_loc->header.stamp);
       return;
     }
 
     if (last_heading_stamp >= heading_msg->header.stamp) {
-      // TODO return or something
       ROS_WARN_STREAM("TRANSFORM | Old heading received prev: " << last_heading_stamp << " update: " << heading_msg->header.stamp);
       return;
     }
@@ -108,7 +97,7 @@ void TransformMaintainer::nav_sat_fix_update_cb(const sensor_msgs::NavSatFixCons
     map_to_odom_ = calculate_map_to_odom_tf(
       host_veh_coord, base_to_global_pos_sensor_,
       earth_to_map_, odom_to_base_link);
-//TODO do we need to sync the heading too? Currently pinpoint's heading and nav_sat_fix are always synched. But this maynot always be the case
+    //TODO do we need to sync the heading too? Currently pinpoint's heading and nav_sat_fix are always synched. But this maynot always be the case
     // Publish newly calculated transforms
     geometry_msgs::TransformStamped map_to_odom_msg 
       = tf2::toMsg(map_to_odom_,  host_veh_loc->header.stamp, map_frame_, odom_frame_);
@@ -116,8 +105,6 @@ void TransformMaintainer::nav_sat_fix_update_cb(const sensor_msgs::NavSatFixCons
     tf_stamped_msgs.push_back(map_to_odom_msg);
 
     // Publish transform
-    // TODO Should we add our calculated transforms ourself here?
-
     for (int i =0; i < tf_stamped_msgs.size(); i++) {
       tf2_buffer_->setTransform(tf_stamped_msgs.at(i), "/saxton_cav/sensor_fusion");
     }
@@ -126,7 +113,7 @@ void TransformMaintainer::nav_sat_fix_update_cb(const sensor_msgs::NavSatFixCons
 
 // Broken out for unit testing
 // Heading is assumed to be in rad
-// TODO all geodesic angles assumed to be in rad
+// All geodesic angles assumed to be in rad
   tf2::Transform TransformMaintainer::calculate_map_to_odom_tf(
     const wgs84_utils::wgs84_coordinate& host_veh_coord,
     const tf2::Transform&  base_to_global_pos_sensor, const tf2::Transform& earth_to_map,
@@ -146,7 +133,6 @@ void TransformMaintainer::nav_sat_fix_update_cb(const sensor_msgs::NavSatFixCons
     // T_m_o = T_m_B * inv(T_o_b)  since b and B are both odom.
     tf2::Vector3 sensor_trans_in_map = global_sensor_in_map;
     // The vehicle heading is relative to NED so over short distances heading in NED = heading in map
-    // TODO Should the global sensor frame be flipped?
     tf2::Vector3 zAxis = tf2::Vector3(0, 0, 1);
     tf2::Quaternion sensor_rot_in_map(zAxis, host_veh_coord.heading);
     sensor_rot_in_map = sensor_rot_in_map.normalize();
@@ -175,24 +161,17 @@ void TransformMaintainer::odometry_update_cb(const nav_msgs::OdometryConstPtr od
 
       no_base_to_local_pos_sensor_ = false;
     }
-  // TODO
-    // if (odom_map_->empty()) {
-    //   std::string msg = "TransformMaintainer odometry_update_cb called before odometry message received";
-    //   ROS_WARN_STREAM("TRANSFORM | " << msg);
-    //   return;
-    // }
+
     //nav_msgs::OdometryConstPtr odometry = odom_map_->begin()->second;
     std::string parent_frame_id = odometry->header.frame_id;
     std::string child_frame_id = odometry->child_frame_id;
-    ROS_WARN_STREAM("Odometry Stamp: " << odometry->header.stamp);// TODO remove
     // If the odometry is already in the base_link frame
     if (parent_frame_id == odom_frame_ && child_frame_id == base_link_frame_) {
       tf2::fromMsg(odometry->pose.pose, odom_to_base_link_);
       // Publish updated transform
       geometry_msgs::TransformStamped odom_to_base_link_msg 
         = tf2::toMsg(odom_to_base_link_,  odometry->header.stamp, odom_frame_, base_link_frame_);
-         // TODO Should we add our calculated transforms ourself here?
-         tf2_buffer_->setTransform(odom_to_base_link_msg, "/saxton_cav/sensor_fusion");
+      tf2_buffer_->setTransform(odom_to_base_link_msg, "/saxton_cav/sensor_fusion");
       tf2_broadcaster_->sendTransform(odom_to_base_link_msg);
 
     } else if (parent_frame_id == odom_frame_ && child_frame_id == local_pos_sensor_frame_) {
@@ -213,7 +192,6 @@ void TransformMaintainer::odometry_update_cb(const nav_msgs::OdometryConstPtr od
       // Publish updated transform
       geometry_msgs::TransformStamped odom_to_base_link_msg 
         = tf2::toMsg(odom_to_base_link_,  odometry->header.stamp, odom_frame_, base_link_frame_);
-         // TODO Should we add our calculated transforms ourself here?
       tf2_buffer_->setTransform(odom_to_base_link_msg, "/saxton_cav/sensor_fusion");
       tf2_broadcaster_->sendTransform(odom_to_base_link_msg);
 

--- a/sensor_fusion/src/transform_maintainer.cpp
+++ b/sensor_fusion/src/transform_maintainer.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2018 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "transform_maintainer.h"
+
+void TransformMaintainer::nav_sat_fix_update_cb(const sensor_msgs::NavSatFixConstPtr host_veh_loc, const cav_msgs::HeadingStampedConstPtr heading_msg)
+{
+    // TODO
+    // // Assign the new host vehicle location
+    // if (navsatfix_map_->empty() || heading_map_->empty()) {
+    //   std::string msg = "TransformMaintainer nav_sat_fix_update_cb called before heading and nav_sat_fix received";
+    //   ROS_WARN_STREAM("TRANSFORM | " << msg);
+    //   return; // If we don't have a heading and a nav sat fix the map->odom transform cannot be calculated
+    // }
+    // sensor_msgs::NavSatFixConstPtr host_veh_loc = navsatfix_map_->begin()->second;
+    
+    // These values must be time synched
+    if (host_veh_loc->header.stamp != heading_msg->header.stamp) {
+      // TODO return or something
+      ROS_WARN_STREAM("TRANSFORM | Tried to update transforms without synched heading and nav_sat_fix");
+      return;
+    }
+
+    if (last_nav_sat_stamp >= host_veh_loc->header.stamp) {
+      // TODO return or something
+      ROS_WARN_STREAM("TRANSFORM | Old nav sat received prev: " << last_nav_sat_stamp << " update: " << host_veh_loc->header.stamp);
+      return;
+    }
+
+    if (last_heading_stamp >= heading_msg->header.stamp) {
+      // TODO return or something
+      ROS_WARN_STREAM("TRANSFORM | Old heading received prev: " << last_heading_stamp << " update: " << heading_msg->header.stamp);
+      return;
+    }
+
+    last_nav_sat_stamp = host_veh_loc->header.stamp;
+    ROS_DEBUG_STREAM("TRANSFORM | New nav sat received: " << last_nav_sat_stamp);
+
+    last_heading_stamp = heading_msg->header.stamp;
+    ROS_DEBUG_STREAM("TRANSFORM | New heading received: " << last_heading_stamp);
+
+    std::string frame_id = host_veh_loc->header.frame_id;
+    if (frame_id != global_pos_sensor_frame_) {
+      std::string msg = "NavSatFix message with unsupported frame received. Frame: " + frame_id;
+      ROS_ERROR_STREAM("TRANSFORM | " << msg);
+      return;
+    }
+    
+    // Check if base_link->position_sensor tf is available. If not look it up
+    if (no_base_to_global_pos_sensor_) {
+      // This transform should be static. No need to look up more than once
+      try {
+        base_to_global_pos_sensor_ = get_transform(base_link_frame_, global_pos_sensor_frame_, ros::Time(0), true);
+      } catch (tf2::TransformException e) {
+        std::string msg = "TransformMaintainer nav_sat_fix_update_cb failed to get transform for global position sensor in base link";
+        ROS_WARN_STREAM("TRANSFORM | " << msg);
+        return;
+      }
+
+      no_base_to_global_pos_sensor_ = false;
+    }
+
+    std::vector<geometry_msgs::TransformStamped> tf_stamped_msgs;
+
+    // Extract geodesic data and convert to radians
+    wgs84_utils::wgs84_coordinate host_veh_coord;
+    host_veh_coord.lat = host_veh_loc->latitude * wgs84_utils::DEG2RAD;
+    host_veh_coord.lon = host_veh_loc->longitude * wgs84_utils::DEG2RAD;
+    host_veh_coord.elevation = host_veh_loc->altitude;
+    host_veh_coord.heading = heading_msg->heading * wgs84_utils::DEG2RAD;
+
+    // Update map location on start
+    if (no_earth_to_map_) { 
+      // Map will be an NED frame on the current vehicle location
+      earth_to_map_ = wgs84_utils::ecef_to_ned_from_loc(host_veh_coord);
+      no_earth_to_map_ = false;
+    }
+    // Keep publishing transform to maintain timestamp
+    geometry_msgs::TransformStamped earth_to_map_msg
+     = tf2::toMsg(earth_to_map_, host_veh_loc->header.stamp, earth_frame_, map_frame_);
+    
+    tf_stamped_msgs.push_back(earth_to_map_msg);
+
+    // Get odom->base_link transform with matching timestamp
+    tf2::Transform odom_to_base_link;
+    try {
+      odom_to_base_link =  get_transform(odom_frame_, base_link_frame_, host_veh_loc->header.stamp, true);
+    } catch (tf2::TransformException e) {
+      std::string msg = "TransformMaintainer nav_sat_fix_update_cb failed to get transform for odom to base_link";
+      ROS_WARN_STREAM("TRANSFORM | " << msg);
+      return;
+    }
+
+    // Calculate updated tf
+    map_to_odom_ = calculate_map_to_odom_tf(
+      host_veh_coord, base_to_global_pos_sensor_,
+      earth_to_map_, odom_to_base_link);
+//TODO do we need to sync the heading too? Currently pinpoint's heading and nav_sat_fix are always synched. But this maynot always be the case
+    // Publish newly calculated transforms
+    geometry_msgs::TransformStamped map_to_odom_msg 
+      = tf2::toMsg(map_to_odom_,  host_veh_loc->header.stamp, map_frame_, odom_frame_);
+    
+    tf_stamped_msgs.push_back(map_to_odom_msg);
+
+    // Publish transform
+    // TODO Should we add our calculated transforms ourself here?
+
+    for (int i =0; i < tf_stamped_msgs.size(); i++) {
+      tf2_buffer_->setTransform(tf_stamped_msgs.at(i), "/saxton_cav/sensor_fusion");
+    }
+    tf2_broadcaster_->sendTransform(tf_stamped_msgs);
+}
+
+// Broken out for unit testing
+// Heading is assumed to be in rad
+// TODO all geodesic angles assumed to be in rad
+  tf2::Transform TransformMaintainer::calculate_map_to_odom_tf(
+    const wgs84_utils::wgs84_coordinate& host_veh_coord,
+    const tf2::Transform&  base_to_global_pos_sensor, const tf2::Transform& earth_to_map,
+    const tf2::Transform& odom_to_base_link)
+  {
+    // Calculate map->global_position_sensor transform
+
+    tf2::Vector3 global_sensor_in_map = wgs84_utils::geodesic_2_cartesian(host_veh_coord, earth_to_map.inverse());
+
+    // T_x_y = transform describing location of y with respect to x
+    // m = map frame
+    // b = baselink frame (from odometry)
+    // B = baselink frame (from nav sat fix)
+    // o = odom frame
+    // p = global position sensor frame
+    // We want to find T_m_o. This is the new transform from map to odom.
+    // T_m_o = T_m_B * inv(T_o_b)  since b and B are both odom.
+    tf2::Vector3 sensor_trans_in_map = global_sensor_in_map;
+    // The vehicle heading is relative to NED so over short distances heading in NED = heading in map
+    // TODO Should the global sensor frame be flipped?
+    tf2::Vector3 zAxis = tf2::Vector3(0, 0, 1);
+    tf2::Quaternion sensor_rot_in_map(zAxis, host_veh_coord.heading);
+    sensor_rot_in_map = sensor_rot_in_map.normalize();
+
+    tf2::Transform T_m_p = tf2::Transform(sensor_rot_in_map, sensor_trans_in_map);
+    tf2::Transform T_B_p = base_to_global_pos_sensor;
+    tf2::Transform T_m_B = T_m_p * T_B_p.inverse();
+    tf2::Transform T_o_b = odom_to_base_link;
+
+    // Modify map to odom with the difference from the expected and real sensor positions
+    return T_m_B * T_o_b.inverse();
+  }
+
+void TransformMaintainer::odometry_update_cb(const nav_msgs::OdometryConstPtr odometry) 
+{
+      // Check if base_link->position_sensor tf is available. If not look it up
+    if (no_base_to_local_pos_sensor_) {
+      // This transform should be static. No need to look up more than once
+      try {
+        base_to_local_pos_sensor_ = get_transform(base_link_frame_, local_pos_sensor_frame_, ros::Time(0), true);
+      } catch (tf2::TransformException e) {
+        std::string msg = "TransformMaintainer odometry_update_cb failed to get transform for local position sensor in base link";
+        ROS_WARN_STREAM("TRANSFORM | " << msg);
+        return;
+      }
+
+      no_base_to_local_pos_sensor_ = false;
+    }
+  // TODO
+    // if (odom_map_->empty()) {
+    //   std::string msg = "TransformMaintainer odometry_update_cb called before odometry message received";
+    //   ROS_WARN_STREAM("TRANSFORM | " << msg);
+    //   return;
+    // }
+    //nav_msgs::OdometryConstPtr odometry = odom_map_->begin()->second;
+    std::string parent_frame_id = odometry->header.frame_id;
+    std::string child_frame_id = odometry->child_frame_id;
+    ROS_WARN_STREAM("Odometry Stamp: " << odometry->header.stamp);// TODO remove
+    // If the odometry is already in the base_link frame
+    if (parent_frame_id == odom_frame_ && child_frame_id == base_link_frame_) {
+      tf2::fromMsg(odometry->pose.pose, odom_to_base_link_);
+      // Publish updated transform
+      geometry_msgs::TransformStamped odom_to_base_link_msg 
+        = tf2::toMsg(odom_to_base_link_,  odometry->header.stamp, odom_frame_, base_link_frame_);
+         // TODO Should we add our calculated transforms ourself here?
+         tf2_buffer_->setTransform(odom_to_base_link_msg, "/saxton_cav/sensor_fusion");
+      tf2_broadcaster_->sendTransform(odom_to_base_link_msg);
+
+    } else if (parent_frame_id == odom_frame_ && child_frame_id == local_pos_sensor_frame_) {
+      // Extract the location of the position sensor relative to the odom frame
+      // Covariance is ignored as filtering was already done by sensor fusion
+      // Calculate odom->base_link
+      // T_x_y = transform describing location of y with respect to x
+      // p = position sensor frame (from odometry)
+      // o = odom frame
+      // b = baselink frame (as has been calculated by odometry up to this point)
+      // T_o_b = T_o_p * inv(T_b_p)
+      tf2::Transform T_o_p;
+      tf2::fromMsg(odometry->pose.pose, T_o_p);
+
+      tf2::Transform T_b_p = base_to_local_pos_sensor_;
+      tf2::Transform T_o_b = T_o_p * T_b_p.inverse();
+      odom_to_base_link_ = T_o_b;
+      // Publish updated transform
+      geometry_msgs::TransformStamped odom_to_base_link_msg 
+        = tf2::toMsg(odom_to_base_link_,  odometry->header.stamp, odom_frame_, base_link_frame_);
+         // TODO Should we add our calculated transforms ourself here?
+      tf2_buffer_->setTransform(odom_to_base_link_msg, "/saxton_cav/sensor_fusion");
+      tf2_broadcaster_->sendTransform(odom_to_base_link_msg);
+
+    } else {
+      std::string msg =
+        "Odometry message with unsupported frames received. ParentFrame: " + parent_frame_id
+          + " ChildFrame: " + child_frame_id;
+      ROS_ERROR_STREAM("TRANSFORM | " << msg);//TODO should we throw an exception here?
+    }
+}
+
+// Helper function
+tf2::Stamped<tf2::Transform> TransformMaintainer::get_transform(
+  std::string parent_frame, std::string child_frame, ros::Time stamp,
+  bool can_use_most_recent_tf) 
+{
+  geometry_msgs::TransformStamped transform_stamped;
+
+  if(tf2_buffer_->canTransform(parent_frame, child_frame, stamp))
+  {
+    transform_stamped = tf2_buffer_->lookupTransform(parent_frame, child_frame, stamp);
+  }
+  else if(tf2_buffer_->canTransform(parent_frame, child_frame, ros::Time(0)) && can_use_most_recent_tf)
+  {
+    ROS_DEBUG_STREAM("TRANSFORM | Using latest transform available"); // This expected on the nav_sat update
+    transform_stamped = tf2_buffer_->lookupTransform(parent_frame, child_frame, ros::Time(0));
+  }
+  else
+  {
+    ROS_WARN_STREAM("No transform available from " << parent_frame << " to " << child_frame);
+
+    throw tf2::TransformException("Failed to get transform");
+  }
+  
+  tf2::Transform result;
+  tf2::fromMsg(transform_stamped.transform, result);
+  tf2::Stamped<tf2::Transform> stamped_result(result, transform_stamped.header.stamp, transform_stamped.header.frame_id);
+  return stamped_result;
+}
+
+
+

--- a/sensor_fusion/src/transform_maintainer.h
+++ b/sensor_fusion/src/transform_maintainer.h
@@ -1,0 +1,158 @@
+#pragma once
+
+/*
+ * Copyright (C) 2018 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "object_tracker.h"
+#include "twist_history_buffer.h"
+#include <sensor_fusion/SensorFusionConfig.h>
+
+#include <nav_msgs/Odometry.h>
+#include <sensor_msgs/NavSatFix.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <cav_msgs/HeadingStamped.h>
+#include <cav_msgs/ExternalObjectList.h>
+#include <cav_msgs/BSM.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <boost/bind.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <bondcpp/bond.h>
+
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <dynamic_reconfigure/server.h>
+
+#include <ros/ros.h>
+
+#include <string>
+#include <unordered_map>
+#include <memory>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <cav_msgs/HeadingStamped.h>
+#include "wgs84_utils.h"
+
+namespace tf2
+{
+    inline // inline is required to make this compile. Not sure why
+    geometry_msgs::TransformStamped toMsg(const tf2::Transform& tf, ros::Time stamp, const std::string& frame_id, const std::string& child_frame_id)
+    {
+        geometry_msgs::TransformStamped msg;
+        msg.transform = tf2::toMsg(tf);
+        msg.header.stamp = stamp;
+        msg.header.frame_id = frame_id;
+        msg.child_frame_id = child_frame_id;
+        
+        return msg;
+    }
+}
+
+/**
+ * TODO
+ * @brief A ROS node that monitors multiple sources to produce a filtered version
+ *
+ * This class monitors all drivers that provide position and tracked objects api*
+ *
+ */
+class TransformMaintainer
+{
+public:
+
+    void init(tf2_ros::Buffer* tf2_buffer, tf2_ros::TransformBroadcaster* tf2_broadcaster,
+        std::unordered_map<std::string, nav_msgs::OdometryConstPtr>* odom_map,
+        std::unordered_map<std::string, sensor_msgs::NavSatFixConstPtr>* navsatfix_map,
+        std::unordered_map<std::string, cav_msgs::HeadingStampedConstPtr>* heading_map,
+        std::string earth_frame, std::string map_frame, std::string odom_frame, 
+        std::string base_link_frame, std::string global_pos_sensor_frame, std::string local_pos_sensor_frame)
+    {
+        tf2_buffer_ = tf2_buffer;
+        tf2_broadcaster_ = tf2_broadcaster;
+        
+        odom_map_ = odom_map;
+        navsatfix_map_ = navsatfix_map;
+        heading_map_ = heading_map;
+        
+        earth_frame_ = earth_frame;
+        map_frame_ = map_frame;
+        odom_frame_ = odom_frame;
+        base_link_frame_ = base_link_frame;
+        global_pos_sensor_frame_ = global_pos_sensor_frame;
+        local_pos_sensor_frame_ = local_pos_sensor_frame;
+    }
+    //void heading_update_cb();
+
+    void nav_sat_fix_update_cb(const sensor_msgs::NavSatFixConstPtr host_veh_loc, const cav_msgs::HeadingStampedConstPtr heading_msg);
+
+    void odometry_update_cb(const nav_msgs::OdometryConstPtr odometry);
+
+    tf2::Stamped<tf2::Transform> get_transform(
+        std::string parent_frame, std::string child_frame, ros::Time stamp,
+        bool can_use_most_recent_tf);
+
+    static tf2::Transform calculate_map_to_odom_tf(
+        const wgs84_utils::wgs84_coordinate& host_veh_coord,
+        const tf2::Transform&  base_to_global_pos_sensor, const tf2::Transform& earth_to_map,
+        const tf2::Transform& odom_to_base_link);
+
+    // void heading_update_cb(const ros::MessageEvent<cav_msgs::HeadingStamped>& event);
+
+    // void nav_sat_fix_update_cb(const ros::MessageEvent<sensor_msgs::NavSatFix>& event);
+
+    // void odometry_update_cb(const ros::MessageEvent<nav_msgs::Odometry>& event);
+
+private:
+
+    tf2_ros::Buffer* tf2_buffer_;
+    tf2_ros::TransformBroadcaster* tf2_broadcaster_;
+
+    std::unordered_map<std::string, nav_msgs::OdometryConstPtr>* odom_map_;
+    std::unordered_map<std::string, sensor_msgs::NavSatFixConstPtr>* navsatfix_map_;
+    std::unordered_map<std::string, cav_msgs::HeadingStampedConstPtr>* heading_map_;
+    
+    // The heading of the vehicle in degrees east of north in an NED frame.
+    // Frame ids
+    std::string earth_frame_;
+    std::string map_frame_;
+    std::string odom_frame_;
+    std::string base_link_frame_;
+    std::string global_pos_sensor_frame_;
+    std::string local_pos_sensor_frame_;
+
+    // Transforms
+    tf2::Transform map_to_odom_ = tf2::Transform::getIdentity();
+    tf2::Transform earth_to_map_;
+    tf2::Transform base_to_local_pos_sensor_;
+    tf2::Transform base_to_global_pos_sensor_;
+    tf2::Transform odom_to_base_link_ = tf2::Transform::getIdentity();// The odom frame will start in the same orientation as the base_link frame on startup
+
+    bool no_earth_to_map_ = true;
+    bool no_base_to_local_pos_sensor_ = true;
+    bool no_base_to_global_pos_sensor_ = true;
+
+    ros::Time last_nav_sat_stamp;
+    ros::Time last_odom_stamp;
+    ros::Time last_heading_stamp;
+};
+

--- a/sensor_fusion/src/transform_maintainer.h
+++ b/sensor_fusion/src/transform_maintainer.h
@@ -54,27 +54,10 @@
 #include <cav_msgs/HeadingStamped.h>
 #include "wgs84_utils.h"
 
-namespace tf2
-{
-    inline // inline is required to make this compile. Not sure why
-    geometry_msgs::TransformStamped toMsg(const tf2::Transform& tf, ros::Time stamp, const std::string& frame_id, const std::string& child_frame_id)
-    {
-        geometry_msgs::TransformStamped msg;
-        msg.transform = tf2::toMsg(tf);
-        msg.header.stamp = stamp;
-        msg.header.frame_id = frame_id;
-        msg.child_frame_id = child_frame_id;
-        
-        return msg;
-    }
-}
-
 /**
- * TODO
- * @brief A ROS node that monitors multiple sources to produce a filtered version
- *
- * This class monitors all drivers that provide position and tracked objects api*
- *
+ * @brief The TransformMaintainer is responsible for updating coordinate transforms
+ * 
+ * Transforms should be updated when new NavSatFix data is available or new odometry data is available.
  */
 class TransformMaintainer
 {

--- a/sensor_fusion/src/wgs84_utils.cpp
+++ b/sensor_fusion/src/wgs84_utils.cpp
@@ -39,7 +39,7 @@
  * @param tie_point
  * @return
  */
-double wgs84_utils::calcMetersPerRadLat(const wgs84_utils::wgs84_coordinate &tie_point) 
+double wgs84_utils::calcMetersPerRadLat(const wgs84_utils::wgs84_coordinate &tie_point)
 {
     double a = EARTH_RADIUS_METERS;
     double e_sq = 0.00669438;
@@ -57,7 +57,7 @@ double wgs84_utils::calcMetersPerRadLat(const wgs84_utils::wgs84_coordinate &tie
  * @param tie_point
  * @return
  */
-double wgs84_utils::calcMetersPerRadLon(const wgs84_utils::wgs84_coordinate &tie_point) 
+double wgs84_utils::calcMetersPerRadLon(const wgs84_utils::wgs84_coordinate &tie_point)
 {
     double a = EARTH_RADIUS_METERS;
     double e_sq = 0.00669438;
@@ -107,8 +107,73 @@ void wgs84_utils::convertToOdom(const wgs84_utils::wgs84_coordinate &src,
 
     Eigen::Quaternion<double> q_offset;
     q_offset = Eigen::AngleAxisd(delta_heading * DEG2RAD, Eigen::Vector3d::UnitZ());
- 
+
     Eigen::Quaternion<double> neu_odom_rot(ned_odom_tf.rotation());
 
     out_rot =  neu_odom_rot * q_offset * odom_rot_ref;
 }
+
+/**
+ * Converts a given WSG-84 geodesic location into a 3d cartesian point
+ * The returned 3d point is defined relative to a frame which has a transform with the ECEF frame.
+ * @param location The geodesic location to convert must be in radians
+ * @param frame2ecefTransform A transform which defines the location of the ECEF frame relative to the 3d point's frame of origin
+ * @return The calculated 3d point
+ */
+//TODO lat/lon must be in radians
+tf2::Vector3 wgs84_utils::geodesic_2_cartesian(const wgs84_utils::wgs84_coordinate &loc, tf2::Transform ecef_in_ned) {
+
+    constexpr double Rea = 6378137.0; // Semi-major axis radius meters
+    constexpr double Rea_sqr = Rea*Rea;
+    constexpr double f = 1.0 / 298.257223563; //The flattening factor
+    constexpr double Reb = Rea * (1.0 - f); // //The semi-minor axis = 6356752.0
+    constexpr double Reb_sqr = Reb*Reb;
+    constexpr double e = 0.08181919084262149; // The first eccentricity (hard coded as optimization) calculated as Math.sqrt(Rea*Rea - Reb*Reb) / Rea;
+    constexpr double e_sqr = e*e;
+    constexpr double e_p = 0.08209443794969568; // e prime (hard coded as optimization) calculated as Math.sqrt((Rea_sqr - Reb_sqr) / Reb_sqr);
+
+
+    // frame2ecefTransform needs to define the position of the ecefFrame relative to the desired frame
+    // Put geodesic in proper units
+    double lonRad = loc.lon;
+    double latRad = loc.lat;
+    double alt = loc.elevation;
+
+    double sinLat = sin(latRad);
+    double sinLon = sin(lonRad);
+    double cosLat = cos(latRad);
+    double cosLon = cos(lonRad);
+
+    double Ne = Rea / sqrt(1.0 - e_sqr * sinLat * sinLat);// The prime vertical radius of curvature
+
+    double x = (Ne + alt)*cosLat*cosLon;
+    double y = (Ne + alt)*cosLat*sinLon;
+    double z = (Ne*(1-e_sqr) + alt) * sinLat;
+
+    tf2::Vector3 ecef_point(x,y,z);
+
+    tf2::Vector3 point_in_ned = ecef_in_ned * ecef_point; 
+    return point_in_ned;
+}
+
+// TODO comment
+// Lat and lon must be in radians
+tf2::Transform wgs84_utils::ecef_to_ned_from_loc(wgs84_coordinate loc) {
+
+    tf2::Vector3 ecef_point = wgs84_utils::geodesic_2_cartesian(loc, tf2::Transform::getIdentity());
+
+    // Rotation matrix of north east down frame with respect to ecef
+    // Found at https://en.wikipedia.org/wiki/North_east_down
+    double sinLat = sin(loc.lat);
+    double sinLon = sin(loc.lon);
+    double cosLat = cos(loc.lat);
+    double cosLon = cos(loc.lon);
+
+ 	  tf2::Matrix3x3 rotMat(
+      -sinLat * cosLon, -sinLon,  -cosLat * cosLon,
+      -sinLat * sinLon,  cosLon,  -cosLat * sinLon,
+                cosLat,       0,           -sinLat 
+    );
+    
+    return tf2::Transform(rotMat, ecef_point);
+  }

--- a/sensor_fusion/src/wgs84_utils.h
+++ b/sensor_fusion/src/wgs84_utils.h
@@ -33,6 +33,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #include <eigen3/Eigen/Geometry>
+#include <tf2/LinearMath/Transform.h>
 
 namespace wgs84_utils
 {
@@ -58,4 +59,9 @@ namespace wgs84_utils
                        Eigen::Vector3d& out_pose,
                        Eigen::Quaternion<double>& out_rot
     );
+
+    tf2::Vector3 geodesic_2_cartesian(const wgs84_coordinate &loc, tf2::Transform ecef_in_ned);
+
+    tf2::Transform ecef_to_ned_from_loc(wgs84_coordinate loc);
+
 }

--- a/sensor_fusion/src/wgs84_utils.h
+++ b/sensor_fusion/src/wgs84_utils.h
@@ -60,7 +60,7 @@ namespace wgs84_utils
                        Eigen::Quaternion<double>& out_rot
     );
 
-    tf2::Vector3 geodesic_2_cartesian(const wgs84_coordinate &loc, tf2::Transform ecef_in_ned);
+    tf2::Vector3 geodesic_to_ecef(const wgs84_coordinate &loc, tf2::Transform ecef_in_ned);
 
     tf2::Transform ecef_to_ned_from_loc(wgs84_coordinate loc);
 

--- a/sensor_fusion/tests/transform_maintainer_test.cpp
+++ b/sensor_fusion/tests/transform_maintainer_test.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2018 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "../src/transform_maintainer.h"
+
+#include <array>
+#include <gtest/gtest.h>
+#include <iostream>
+
+/**
+ * Helper function calculates if two vectors are equal within some epsilon
+ */
+bool equal_vector3(tf2::Vector3 v1, tf2::Vector3 v2, double epsilon) {
+  return 
+    fabs(v1.getX() - v2.getX()) < epsilon &&
+    fabs(v1.getY() - v2.getY()) < epsilon &&
+    fabs(v1.getZ() - v2.getZ()) < epsilon;
+}
+
+/**
+ * Helper function calculates if two quaternions are equal within some epsilon
+ */
+bool equal_quaternion(tf2::Quaternion v1, tf2::Quaternion v2, double epsilon) {
+  return 
+    equal_vector3(v1.getAxis(), v2.getAxis(), epsilon) &&
+    fabs(v1.getW() - v2.getW()) < epsilon;
+}   
+/**
+ * Tests the handling calculation of map->odom transform updates
+ */
+TEST(MapToOdomUpdateTest, test1)
+{
+
+  // Set the transform from base_link to position sensor
+  tf2::Transform base_to_global_pos_sensor = tf2::Transform::getIdentity();
+
+  // Location at prime meridian and equator with 90 deg initial heading
+  wgs84_utils::wgs84_coordinate host_veh_coord;
+  host_veh_coord.lat = 0.0 * wgs84_utils::DEG2RAD;
+  host_veh_coord.lon = 0.0 * wgs84_utils::DEG2RAD;
+  host_veh_coord.elevation = 0.0;
+  host_veh_coord.heading = 90.0 * wgs84_utils::DEG2RAD;
+
+  // an NED at lat = 0 lon = 0 is rotated -90 deg around the ecef y-axis
+  tf2::Vector3 earth_to_map_trans(6378137.0, 0, 0);
+  tf2::Vector3 y_axis(0,1,0);
+  tf2::Quaternion earth_to_map_rot(y_axis, -90.0 * wgs84_utils::DEG2RAD);
+  tf2::Transform earth_to_map(earth_to_map_rot, earth_to_map_trans);
+
+  // Vehicle has not moved some transform from odom to base link should be identity
+  tf2::Transform odom_to_base_link = tf2::Transform::getIdentity();
+
+  tf2::Transform map_to_odom = TransformMaintainer::calculate_map_to_odom_tf(
+    host_veh_coord,
+    base_to_global_pos_sensor, 
+    earth_to_map,
+    odom_to_base_link
+  );
+
+  // The heading of 90 degrees means
+  // the actual orientation of odom when there has been no odometry is with +x being due east
+  tf2::Vector3 solution_trans(0, 0, 0);
+  tf2::Vector3 sol_rot_axis(0,0,1);
+  tf2::Quaternion solution_rot = tf2::Quaternion(sol_rot_axis, 90 * wgs84_utils::DEG2RAD);
+
+  EXPECT_EQ(true, equal_vector3(map_to_odom.getOrigin(), solution_trans, 0.00001));
+  EXPECT_EQ(true, equal_quaternion(map_to_odom.getRotation(), solution_rot, 0.0001));
+
+  // Odometry moves the vehicle 10 meters along north axis
+  tf2::Vector3 odom_to_base_link_trans(10,0,0);
+  odom_to_base_link.setOrigin(odom_to_base_link_trans);
+  odom_to_base_link.setRotation(tf2::Quaternion::getIdentity());
+
+  // Actual location should be at (1,10,0) in the map
+  host_veh_coord.lat = 9.043694770492556e-6 * wgs84_utils::DEG2RAD;
+  host_veh_coord.lon = 8.983152841187856e-5 * wgs84_utils::DEG2RAD;
+  host_veh_coord.elevation = 7.917173206806183e-6;
+  // Call tf update
+  map_to_odom = TransformMaintainer::calculate_map_to_odom_tf(
+    host_veh_coord,
+    base_to_global_pos_sensor, 
+    earth_to_map,
+    odom_to_base_link
+  );
+
+  // Compare new map_to_odom
+  // The odom frame should be moved +1 along the map's +x axis
+  solution_trans = tf2::Vector3(1, 0, 0);
+  sol_rot_axis = tf2::Vector3(0,0,1);
+  solution_rot = tf2::Quaternion(sol_rot_axis, 90 * wgs84_utils::DEG2RAD);
+  
+  EXPECT_EQ(true, equal_vector3(map_to_odom.getOrigin(), solution_trans, 0.00001));
+  EXPECT_EQ(true, equal_quaternion(map_to_odom.getRotation(), solution_rot, 0.0001));
+}
+
+int main(int argc, char**argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# PR Details
Resolves Issue #88 
## Description
Prevents a race condition between sensor fusion and roadway described in the referenced issue. TF publication is moved to sensor fusion. The code is a direct port of the TransformMaintainer.java class from the roadway package into C++. This code was previously in the fix/sensor_fusion_lat_lon_conv branch of the pre-release repo, but was never merged in due to it being a lower priority issue. After having difficulties with detecting NCVs while testing the Traffic Signal Plugin one day, I moved the port. I have not observed an issues resulting from this change in the week or so since performing the port.

If this is merged in the documentation for roadway/sensor fusion will need to be updated. I will add a Jira ticket for that.  

## Related Issue
#88 

## Motivation and Context

Improve object detection and sensor fusion

## How Has This Been Tested?

C++ unit tests were created by porting the java tests and can be run with the catkin_make run_tests command. 

The code has been running during Traffic Signal Plugin tests for the last week to week and a half. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
