### PR TITLE
Allow lights when disengaged

### DIFF
--- a/srx_controller/include/srx_controller/srx_dbw_controller.h
+++ b/srx_controller/include/srx_controller/srx_dbw_controller.h
@@ -269,6 +269,7 @@ private:
     std::condition_variable cv_;
     volatile bool running_ = false;
     std::shared_ptr<std::thread> process_thread_;
+    bool allow_lights_when_disengaged_ = false;
 
     // Control message is maintains the state of the previous message sent
     ControlMessage_t ctrl_msg_;

--- a/srx_controller/launch/srx_controller.launch
+++ b/srx_controller/launch/srx_controller.launch
@@ -1,13 +1,17 @@
 <launch>
 	<arg name="srx_controller_can_device" default="can0" />
+
     <arg name="k_p" default="0.1" />
     <arg name="k_i" default="0.01" />
     <arg name="k_d" default="0.005" />
+
+    <arg name="allow_lights_when_disengaged" default="false" />
 
     <node name="srx_controller" pkg="srx_controller" type="srx_controller_node" output="screen">
         <param name="k_p" value="$(arg k_p)" />
         <param name="k_i" value="$(arg k_i)" />
         <param name="k_d" value="$(arg k_d)" />
+        <param name="allow_lights_when_disengaged" value="$(arg allow_lights_when_disengaged)" />
 
         <remap from="received_messages" to="$(arg srx_controller_can_device)/received_messages" />
         <remap from="sent_messages" to="$(arg srx_controller_can_device)/sent_messages" />


### PR DESCRIPTION
# PR Details
Allows the light bar to be controlled even when the vehicle is not under automated control.
A parameter was added to allow for this feature to be turned on and off.

## Related Issue

#103 

## Motivation and Context

We want the light bar on when the vehicle is off for demonstration at TRB

## How Has This Been Tested?

Yes on the silver cadillac. Used when only the electronics were powered. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
