### PR TITLE
Fix guidance unit tests

### DIFF
--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandler.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandler.java
@@ -239,6 +239,7 @@ public class PluginLifecycleHandler {
      * @throws IllegalStateException
      */
     public void terminate() {
+    	System.out.println(state.get().name());
         switch (state.get()) {
             case UNINITIALIZED:
                 throw new IllegalStateException();

--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandler.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandler.java
@@ -239,7 +239,7 @@ public class PluginLifecycleHandler {
      * @throws IllegalStateException
      */
     public void terminate() {
-    	System.out.println(state.get().name());
+    	System.out.println("See here!!!!!!!" + state.get().name());
         switch (state.get()) {
             case UNINITIALIZED:
                 throw new IllegalStateException();

--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandler.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandler.java
@@ -216,13 +216,13 @@ public class PluginLifecycleHandler {
      */
     private void doTerminate() {
         log.info("PLUGIN", "Terminating " + plugin.getVersionInfo().componentName() + ":" + plugin.getVersionInfo().revisionString());
-        t.interrupt();
         tasks.clear();
         state.set(PluginState.DESTROYING);
         try {
             tasks.put(new TerminatePluginTask(plugin, new TaskCompletionCallback() {
                 @Override public void onComplete() {
                     state.set(PluginState.DESTROYED);
+                    Thread.currentThread().interrupt();
                 }
             }));
         } catch (InterruptedException e) {
@@ -239,7 +239,6 @@ public class PluginLifecycleHandler {
      * @throws IllegalStateException
      */
     public void terminate() {
-    	System.out.println("See here!!!!!!!" + state.get().name());
         switch (state.get()) {
             case UNINITIALIZED:
                 throw new IllegalStateException();

--- a/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
+++ b/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
@@ -18,17 +18,10 @@ package gov.dot.fhwa.saxton.carma.guidance.plugins;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.listeners.InvocationListener;
-import org.mockito.listeners.MethodInvocationReport;
-import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-
-import javax.naming.CompoundName;
 
 import gov.dot.fhwa.saxton.carma.guidance.util.ILogger;
 import gov.dot.fhwa.saxton.carma.guidance.util.ILoggerFactory;
@@ -39,7 +32,7 @@ public class PluginLifecycleHandlerTest {
     @Before public void setUp() throws Exception {
         ILoggerFactory mockFact = mock(ILoggerFactory.class);
         ILogger mockLogger = mock(ILogger.class);
-        when(mockFact.createLoggerForClass(anyObject())).thenReturn(mockLogger);
+        when(mockFact.createLoggerForClass(any())).thenReturn(mockLogger);
         LoggerManager.setLoggerFactory(mockFact);
         p = mock(IPlugin.class);
         doAnswer((in) -> {
@@ -97,11 +90,8 @@ public class PluginLifecycleHandlerTest {
         Thread.sleep(100);
         handler.suspend();
         Thread.sleep(100);
-        System.out.println("Start to terminate!");
         handler.terminate();
         Thread.sleep(100);
-        Thread.yield();
-        System.out.println("Ends on termination!");
         verify(p).onTerminate();
         running = false;
     }

--- a/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
+++ b/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
@@ -35,8 +35,6 @@ import gov.dot.fhwa.saxton.carma.guidance.util.ILoggerFactory;
 import gov.dot.fhwa.saxton.carma.guidance.util.LoggerManager;
 import gov.dot.fhwa.saxton.utils.ComponentVersion;
 
-
-@Ignore("TODO Needs to be updated to be deterministic")
 public class PluginLifecycleHandlerTest {
     @Before public void setUp() throws Exception {
         ILoggerFactory mockFact = mock(ILoggerFactory.class);

--- a/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
+++ b/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
@@ -98,7 +98,7 @@ public class PluginLifecycleHandlerTest {
         handler.suspend();
         Thread.sleep(100);
         handler.terminate();
-        Thread.sleep(100);
+        Thread.sleep(500);
         verify(p).onTerminate();
         running = false;
     }

--- a/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
+++ b/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/plugins/PluginLifecycleHandlerTest.java
@@ -97,8 +97,11 @@ public class PluginLifecycleHandlerTest {
         Thread.sleep(100);
         handler.suspend();
         Thread.sleep(100);
+        System.out.println("Start to terminate!");
         handler.terminate();
-        Thread.sleep(500);
+        Thread.sleep(100);
+        Thread.yield();
+        System.out.println("Ends on termination!");
         verify(p).onTerminate();
         running = false;
     }

--- a/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/trajectory/LocalSpeedLimitConstraintTest.java
+++ b/carmajava/guidance/src/test/java/gov/dot/fhwa/saxton/carma/guidance/trajectory/LocalSpeedLimitConstraintTest.java
@@ -25,7 +25,7 @@ import org.ros.node.NodeConfiguration;
 import std_msgs.Header;
 
 import static org.junit.Assert.*;
-
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import cav_msgs.Route;
@@ -33,10 +33,13 @@ import cav_msgs.RouteSegment;
 import cav_msgs.RouteWaypoint;
 import gov.dot.fhwa.saxton.carma.guidance.maneuvers.ISimpleManeuver;
 import gov.dot.fhwa.saxton.carma.guidance.maneuvers.LongitudinalManeuver;
+import gov.dot.fhwa.saxton.carma.guidance.util.ILogger;
+import gov.dot.fhwa.saxton.carma.guidance.util.ILoggerFactory;
+import gov.dot.fhwa.saxton.carma.guidance.util.LoggerManager;
+
 import java.util.ArrayList;
 import java.util.List;
 
-@Ignore("TODO Resolve NPE in test appearing in CI")
 public class LocalSpeedLimitConstraintTest {
   private NodeConfiguration nodeConfig = NodeConfiguration.newPrivate();
   private MessageFactory messageFactory = nodeConfig.getTopicMessageFactory();
@@ -89,6 +92,12 @@ public class LocalSpeedLimitConstraintTest {
 
   @Before
   public void setup() {
+	
+	ILoggerFactory mockFact = mock(ILoggerFactory.class);
+    ILogger mockLogger = mock(ILogger.class);
+    when(mockFact.createLoggerForClass(any())).thenReturn(mockLogger);
+    LoggerManager.setLoggerFactory(mockFact);
+      
     List<Double> speeds = new ArrayList<>();
     speeds.add(10.0);
     speeds.add(20.0);


### PR DESCRIPTION
# PR Details
Two fixes are in this PR. One is for fixing PluginLifecycleHandler race condition. The other is to fix a NPE in LocalSpeedLimitConstraintTest.
## Description
For PluginLifecycleHandler, the ```doTerminate()``` function interrupts the PluginLifecycleHandlerWorker thread before it give the TerminatePluginTask task to PluginLifecycleHandlerWorker. So there is a race condition where the PluginLifecycleHandlerWorker stops looping before it executes TerminatePluginTask job.
## Related Issue
#175 
## Motivation and Context
Fix #175 
## How Has This Been Tested?
Passed 5 times locally and twice on CI build.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
