### PR TITLE
Remove interactions with interface mgr

### DIFF
--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/GuidanceStateHandler.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/GuidanceStateHandler.java
@@ -18,14 +18,8 @@ package gov.dot.fhwa.saxton.carma.guidance;
 
 import gov.dot.fhwa.saxton.carma.guidance.pubsub.IPubSubService;
 import gov.dot.fhwa.saxton.carma.guidance.pubsub.IPublisher;
-import gov.dot.fhwa.saxton.carma.guidance.pubsub.IService;
 import gov.dot.fhwa.saxton.carma.guidance.pubsub.ISubscriber;
 import gov.dot.fhwa.saxton.carma.guidance.pubsub.OnMessageCallback;
-import gov.dot.fhwa.saxton.carma.guidance.pubsub.OnServiceResponseCallback;
-import gov.dot.fhwa.saxton.carma.guidance.pubsub.TopicNotFoundException;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.ros.exception.RosRuntimeException;
 import org.ros.exception.ServiceException;
@@ -36,9 +30,6 @@ import org.ros.node.service.ServiceServer;
 import cav_msgs.RobotEnabled;
 import cav_msgs.RouteEvent;
 import cav_msgs.SystemAlert;
-import cav_srvs.GetDriversWithCapabilities;
-import cav_srvs.GetDriversWithCapabilitiesRequest;
-import cav_srvs.GetDriversWithCapabilitiesResponse;
 import cav_srvs.SetGuidanceActive;
 import cav_srvs.SetGuidanceActiveRequest;
 import cav_srvs.SetGuidanceActiveResponse;
@@ -49,7 +40,6 @@ import cav_srvs.SetGuidanceActiveResponse;
  * Also listens for route_state changes that would indicate the need for a Guidance shutdown
  */
 public class GuidanceStateHandler extends GuidanceComponent implements IStateChangeListener {
-    private static final String ROBOTIC_STATUS_CAPABILITY = "control/robot_status";
     
     protected long shutdownDelayMs = 5000;
     protected boolean robotStatus = false;
@@ -58,7 +48,6 @@ public class GuidanceStateHandler extends GuidanceComponent implements IStateCha
     protected ISubscriber<SystemAlert> systemAlertSub;
     protected ISubscriber<RobotEnabled> robotStatusSub;
     protected IPublisher<SystemAlert> systemAlertPub;
-    protected IService<GetDriversWithCapabilitiesRequest, GetDriversWithCapabilitiesResponse> driverCapabilityService;
     protected ServiceServer<SetGuidanceActiveRequest, SetGuidanceActiveResponse> guidanceActiveService;
 
     public GuidanceStateHandler(GuidanceStateMachine stateMachine, IPubSubService pubSubService, ConnectedNode node) {
@@ -138,74 +127,24 @@ public class GuidanceStateHandler extends GuidanceComponent implements IStateCha
 
     @Override
     public void onSystemReady() {
-        try {
-            driverCapabilityService = pubSubService.getServiceForTopic("get_drivers_with_capabilities",
-                    GetDriversWithCapabilities._TYPE);
-        } catch (TopicNotFoundException tnfe) {
-            stateMachine.processEvent(GuidanceEvent.PANIC);
-            log.fatal("SHUTDOWN", "Interface manager not found.");
-        }
         
-        // Build request message
-        GetDriversWithCapabilitiesRequest req = driverCapabilityService.newMessage();
-
-        List<String> reqdCapabilities = new ArrayList<>();
-        reqdCapabilities.add(ROBOTIC_STATUS_CAPABILITY);
-        req.setCapabilities(reqdCapabilities);
-
-        // Work around to pass a final object into our anonymous inner class so we can get the response
-        final GetDriversWithCapabilitiesResponse[] drivers = new GetDriversWithCapabilitiesResponse[1];
-        drivers[0] = null;
-
-        // Call the InterfaceManager to see if we have a driver that matches our requirements
-        driverCapabilityService.call(req, new OnServiceResponseCallback<GetDriversWithCapabilitiesResponse>() {
-            @Override
-            public void onSuccess(GetDriversWithCapabilitiesResponse msg) {
-                log.debug("Received GetDriversWithCapabilitiesResponse");
-                for (String driverName : msg.getDriverData()) {
-                    log.debug(getComponentName() + " discovered driver: " + driverName);
-                }
-                drivers[0] = msg;
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                stateMachine.processEvent(GuidanceEvent.PANIC);
-                log.fatal("InterfaceManager failed to return a control/robot_status capable driver!!!");
-            }
-        });
-        
-        String robotStatusTopic = null;
-        if(drivers[0] != null) {
-            for(String url : drivers[0].getDriverData()) {
-                if(url.endsWith(ROBOTIC_STATUS_CAPABILITY)) {
-                    robotStatusTopic = url;
-                    break;
-                }
-            }                
-        }
-        
-        if(robotStatusTopic != null) {
-            log.debug(getComponentName() + " is connecting to " + robotStatusTopic);
-            robotStatusSub = pubSubService.getSubscriberForTopic(robotStatusTopic, RobotEnabled._TYPE);
-            if(robotStatusSub != null) {
-                robotStatusSub.registerOnMessageCallback(new OnMessageCallback<RobotEnabled>() {
-                    @Override
-                    public void onMessage(RobotEnabled msg) {
-                        if(!robotStatus && msg.getRobotActive()) {
-                            stateMachine.processEvent(GuidanceEvent.START_ROUTE);
-                            log.info("GUIDANCE_STATE", "Guidance StateMachine received START_ROUTE event");
-                            robotStatus = true;
-                        } else if(robotStatus && !msg.getRobotActive()) {
-                            stateMachine.processEvent(GuidanceEvent.ROBOT_DISABLED);
-                            log.info("GUIDANCE_STATE", "Guidance StateMachine received ROBOT_DISABLED event");
-                            robotStatus = false;
-                        }
+        robotStatusSub = pubSubService.getSubscriberForTopic("robot_enabled", RobotEnabled._TYPE);
+        if(robotStatusSub != null) {
+            robotStatusSub.registerOnMessageCallback(new OnMessageCallback<RobotEnabled>() {
+                @Override
+                public void onMessage(RobotEnabled msg) {
+                    if(!robotStatus && msg.getRobotActive()) {
+                        stateMachine.processEvent(GuidanceEvent.START_ROUTE);
+                        log.info("GUIDANCE_STATE", "Guidance StateMachine received START_ROUTE event");
+                        robotStatus = true;
+                    } else if(robotStatus && !msg.getRobotActive()) {
+                        stateMachine.processEvent(GuidanceEvent.ROBOT_DISABLED);
+                        log.info("GUIDANCE_STATE", "Guidance StateMachine received ROBOT_DISABLED event");
+                        robotStatus = false;
                     }
-                });
-            }
+                }
+            });
         }
-        
         currentState.set(GuidanceState.DRIVERS_READY);
     }
 

--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/GuidanceStateHandler.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/GuidanceStateHandler.java
@@ -128,7 +128,7 @@ public class GuidanceStateHandler extends GuidanceComponent implements IStateCha
     @Override
     public void onSystemReady() {
         
-        robotStatusSub = pubSubService.getSubscriberForTopic("robot_enabled", RobotEnabled._TYPE);
+        robotStatusSub = pubSubService.getSubscriberForTopic("robot_status", RobotEnabled._TYPE);
         if(robotStatusSub != null) {
             robotStatusSub.registerOnMessageCallback(new OnMessageCallback<RobotEnabled>() {
                 @Override

--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/Tracking.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/Tracking.java
@@ -112,8 +112,8 @@ public class Tracking extends GuidanceComponent implements IStateChangeListener,
 	protected TreeMap<Long, double[]> speedTimeTree = new TreeMap<Long, double[]>((a, b) -> Long.compare(a, b));
 	protected double trajectoryStartLocation = 0;
 	protected long trajectoryStartTime = 0;
-	private static final String DRIVER_BASE_PATH = "/saxton_cav/drivers";
-	private static final String CAN_DRIVER_BASE_PATH = "/srx_can/can/";
+	
+	private static final String CAN_DRIVER_BASE_PATH = "/can/";
 	private static final String STEERING_WHEEL_CAPABILITY = "steering_wheel_angle";
 	private static final String BRAKE_POSITION_CAPABILITY = "brake_position";
 	private static final String TRANSMISSION_STATE_CAPABILITY = "transmission_state";
@@ -172,15 +172,15 @@ public class Tracking extends GuidanceComponent implements IStateChangeListener,
         // Make service call to get drivers
         log.debug("Trying to get get_drivers_with_capabilities service...");
 
-        steeringWheelSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + STEERING_WHEEL_CAPABILITY, Float64._TYPE);
-        brakeSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + BRAKE_POSITION_CAPABILITY, Float64._TYPE);
-        transmissionSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + TRANSMISSION_STATE_CAPABILITY, j2735_msgs.TransmissionState._TYPE);
-        tractionActiveSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + TRACTION_CTRL_ACTIVE_CAPABILITY, std_msgs.Bool._TYPE);
-        tractionEnabledSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + TRACTION_CTRL_ENABLED_CAPABILITY, std_msgs.Bool._TYPE);
-        antilockBrakeSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + ANTILOCK_BRAKES_ACTIVE_CAPABILITY, std_msgs.Bool._TYPE);
-        stabilityActiveSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + STABILITY_CTRL_ACTIVE_CAPABILITY, std_msgs.Bool._TYPE);
-        stabilityEnabledSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + STABILITY_CTRL_ENABLED_CAPABILITY, std_msgs.Bool._TYPE);
-        parkingBrakeSubscriber = pubSubService.getSubscriberForTopic(DRIVER_BASE_PATH + CAN_DRIVER_BASE_PATH + PARKING_BRAKE_CAPABILITY, std_msgs.Bool._TYPE);
+        steeringWheelSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + STEERING_WHEEL_CAPABILITY, Float64._TYPE);
+        brakeSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + BRAKE_POSITION_CAPABILITY, Float64._TYPE);
+        transmissionSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + TRANSMISSION_STATE_CAPABILITY, j2735_msgs.TransmissionState._TYPE);
+        tractionActiveSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + TRACTION_CTRL_ACTIVE_CAPABILITY, std_msgs.Bool._TYPE);
+        tractionEnabledSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + TRACTION_CTRL_ENABLED_CAPABILITY, std_msgs.Bool._TYPE);
+        antilockBrakeSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + ANTILOCK_BRAKES_ACTIVE_CAPABILITY, std_msgs.Bool._TYPE);
+        stabilityActiveSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + STABILITY_CTRL_ACTIVE_CAPABILITY, std_msgs.Bool._TYPE);
+        stabilityEnabledSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + STABILITY_CTRL_ENABLED_CAPABILITY, std_msgs.Bool._TYPE);
+        parkingBrakeSubscriber = pubSubService.getSubscriberForTopic(CAN_DRIVER_BASE_PATH + PARKING_BRAKE_CAPABILITY, std_msgs.Bool._TYPE);
 
         if (steeringWheelSubscriber == null || brakeSubscriber == null || transmissionSubscriber == null
                 || tractionActiveSubscriber == null || tractionEnabledSubscriber == null

--- a/carmajava/launch/saxton_cav_src.launch
+++ b/carmajava/launch/saxton_cav_src.launch
@@ -326,9 +326,9 @@
         <remap from="outgoing_mobility_operation"
                to="/$(arg TOP_NS)/$(arg GUIDE_NS)/outgoing_mobility_operation"/>
         <remap from="inbound_binary_msg"
-               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/dsrc/comms/inbound_binary_msg"/>
+               to="/comms/inbound_binary_msg"/>
         <remap from="outbound_binary_msg"
-               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/dsrc/comms/outbound_binary_msg"/>
+               to="/comms/outbound_binary_msg"/>
 
       </node>
     </group>
@@ -354,8 +354,8 @@
         <!-- Arbitrator Thread-->
         <remap from="route_state"
                to="/$(arg TOP_NS)/$(arg RT_NS)/route_state"/>
-        <remap from="robot_enabled"
-               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/robot_status"/>
+        <remap from="robot_status"
+               to="/control/robot_status"/>
         
         <!-- GuidanceStateHandler Thread-->
         <remap from="route_event"
@@ -363,11 +363,11 @@
         
         <!-- GuidanceCommands Thread -->
         <remap from="cmd_speed"
-               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/cmd_speed"/>
+               to="/control/cmd_speed"/>
         <remap from="cmd_longitudinal_effort"
-               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/cmd_longitudinal_effort"/>
+               to="/control/cmd_longitudinal_effort"/>
         <remap from="enable_robotic"
-               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/enable_robotic"/>
+               to="/srx_controller/control/enable_robotic"/>
 
         <!-- Tracking Thread-->
         <!-- Params -->
@@ -422,7 +422,7 @@
 
         <!-- LightBar Thread -->
         <remap from="set_lights"
-               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/set_lights"/>
+               to="/control/set_lights"/>
                
       </node>
     </group>

--- a/carmajava/launch/saxton_cav_src.launch
+++ b/carmajava/launch/saxton_cav_src.launch
@@ -325,8 +325,11 @@
                to="/$(arg TOP_NS)/$(arg GUIDE_NS)/outgoing_mobility_response"/>
         <remap from="outgoing_mobility_operation"
                to="/$(arg TOP_NS)/$(arg GUIDE_NS)/outgoing_mobility_operation"/>
-        <remap from="get_drivers_with_capabilities"
-               to="/$(arg TOP_NS)/$(arg INTR_NS)/get_drivers_with_capabilities"/>
+        <remap from="inbound_binary_msg"
+               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/dsrc/comms/inbound_binary_msg"/>
+        <remap from="outbound_binary_msg"
+               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/dsrc/comms/outbound_binary_msg"/>
+
       </node>
     </group>
 
@@ -358,6 +361,14 @@
         <remap from="route_event"
                to="/$(arg TOP_NS)/$(arg RT_NS)/route_event"/>
         
+        <!-- GuidanceCommands Thread -->
+        <remap from="cmd_speed"
+               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/cmd_speed"/>
+        <remap from="cmd_longitudinal_effort"
+               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/cmd_longitudinal_effort"/>
+        <remap from="enable_robotic"
+               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/enable_robotic"/>
+
         <!-- Tracking Thread-->
         <!-- Params -->
         <remap from="vehicle_length"
@@ -377,10 +388,6 @@
                to="/$(arg TOP_NS)/$(arg RD_NS)/get_transform"/>
         <remap from="acceleration"
                to="/$(arg TOP_NS)/$(arg SF_NS)/filtered/acceleration"/>
-
-        <!-- Trajectory Thread-->
-        <remap from="get_drivers_with_capabilities"
-               to="/$(arg TOP_NS)/$(arg INTR_NS)/get_drivers_with_capabilities"/>
 
         <!-- Trajectory and Arbitrator -->
         <remap from="route_state" to="/$(arg TOP_NS)/$(arg RT_NS)/route_state"/>
@@ -412,6 +419,10 @@
                to="/$(arg TOP_NS)/$(arg MSG_NS)/incoming_map"/>
         <remap from="incoming_spat"
                to="/$(arg TOP_NS)/$(arg MSG_NS)/incoming_spat"/>
+
+        <!-- LightBar Thread -->
+        <remap from="set_lights"
+               to="/$(arg TOP_NS)/$(arg DRIVER_NS)/srx_controller/control/set_lights"/>
                
       </node>
     </group>

--- a/carmajava/launch/saxton_cav_src.launch
+++ b/carmajava/launch/saxton_cav_src.launch
@@ -367,7 +367,7 @@
         <remap from="cmd_longitudinal_effort"
                to="/control/cmd_longitudinal_effort"/>
         <remap from="enable_robotic"
-               to="/srx_controller/control/enable_robotic"/>
+               to="/control/enable_robotic"/>
 
         <!-- Tracking Thread-->
         <!-- Params -->

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockCANDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockCANDriver.java
@@ -78,24 +78,24 @@ public class MockCANDriver extends AbstractMockDriver {
     super(connectedNode);
     // Topics
     // Published
-    accPub = connectedNode.newPublisher("~/can/acc_engaged", std_msgs.Bool._TYPE);
-    accelPub = connectedNode.newPublisher("~/can/acceleration", std_msgs.Float64._TYPE);
-    brakeLightsPub = connectedNode.newPublisher("~/can/brake_lights", std_msgs.Bool._TYPE);
-    brakePositionPub = connectedNode.newPublisher("~/can/brake_position", std_msgs.Float64._TYPE);
-    engineSpeedPub = connectedNode.newPublisher("~/can/engine_speed", std_msgs.Float64._TYPE);
-    fuelFlowPub = connectedNode.newPublisher("~/can/fuel_flow", std_msgs.Float64._TYPE);
-    odometryPub = connectedNode.newPublisher("~/can/odometer", std_msgs.Float64._TYPE);
-    parkingBrakePub = connectedNode.newPublisher("~/can/parking_brake", std_msgs.Bool._TYPE);
-    speedPub = connectedNode.newPublisher("~/can/speed", std_msgs.Float64._TYPE);
-    steeringPub = connectedNode.newPublisher("~/can/steering_wheel_angle", std_msgs.Float64._TYPE);
-    throttlePub = connectedNode.newPublisher("~/can/throttle_position", std_msgs.Float64._TYPE);
-    turnSignalPub = connectedNode.newPublisher("~/can/turn_signal_state", cav_msgs.TurnSignal._TYPE);
-    transmissionPub = connectedNode.newPublisher("~/can/transmission_state", j2735_msgs.TransmissionState._TYPE);
-    tractionActivePub = connectedNode.newPublisher("~/can/traction_ctrl_active", std_msgs.Bool._TYPE);
-    tractionEnabledPub = connectedNode.newPublisher("~/can/traction_ctrl_enabled", std_msgs.Bool._TYPE);
-    antilockBrakePub = connectedNode.newPublisher("~/can/antilock_brakes_active", std_msgs.Bool._TYPE);
-    stabilityActivePub = connectedNode.newPublisher("~/can/stability_ctrl_active", std_msgs.Bool._TYPE);
-    stabilityEnabledPub = connectedNode.newPublisher("~/can/stability_ctrl_enabled", std_msgs.Bool._TYPE);
+    accPub = connectedNode.newPublisher("/can/acc_engaged", std_msgs.Bool._TYPE);
+    accelPub = connectedNode.newPublisher("/can/acceleration", std_msgs.Float64._TYPE);
+    brakeLightsPub = connectedNode.newPublisher("/can/brake_lights", std_msgs.Bool._TYPE);
+    brakePositionPub = connectedNode.newPublisher("/can/brake_position", std_msgs.Float64._TYPE);
+    engineSpeedPub = connectedNode.newPublisher("/can/engine_speed", std_msgs.Float64._TYPE);
+    fuelFlowPub = connectedNode.newPublisher("/can/fuel_flow", std_msgs.Float64._TYPE);
+    odometryPub = connectedNode.newPublisher("/can/odometer", std_msgs.Float64._TYPE);
+    parkingBrakePub = connectedNode.newPublisher("/can/parking_brake", std_msgs.Bool._TYPE);
+    speedPub = connectedNode.newPublisher("/can/speed", std_msgs.Float64._TYPE);
+    steeringPub = connectedNode.newPublisher("/can/steering_wheel_angle", std_msgs.Float64._TYPE);
+    throttlePub = connectedNode.newPublisher("/can/throttle_position", std_msgs.Float64._TYPE);
+    turnSignalPub = connectedNode.newPublisher("/can/turn_signal_state", cav_msgs.TurnSignal._TYPE);
+    transmissionPub = connectedNode.newPublisher("/can/transmission_state", j2735_msgs.TransmissionState._TYPE);
+    tractionActivePub = connectedNode.newPublisher("/can/traction_ctrl_active", std_msgs.Bool._TYPE);
+    tractionEnabledPub = connectedNode.newPublisher("/can/traction_ctrl_enabled", std_msgs.Bool._TYPE);
+    antilockBrakePub = connectedNode.newPublisher("/can/antilock_brakes_active", std_msgs.Bool._TYPE);
+    stabilityActivePub = connectedNode.newPublisher("/can/stability_ctrl_active", std_msgs.Bool._TYPE);
+    stabilityEnabledPub = connectedNode.newPublisher("/can/stability_ctrl_enabled", std_msgs.Bool._TYPE);
   }
 
   @Override protected void publishData(List<String[]> data) {

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockDSRCDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockDSRCDriver.java
@@ -17,14 +17,9 @@
 package gov.dot.fhwa.saxton.carma.mock_drivers;
 
 import cav_msgs.ByteArray;
-import cav_srvs.SendMessageRequest;
-import cav_srvs.SendMessageResponse;
 import org.jboss.netty.buffer.ChannelBuffers;
-import org.ros.exception.ServiceException;
 import org.ros.message.MessageListener;
 import org.ros.node.ConnectedNode;
-import org.ros.node.service.ServiceResponseBuilder;
-import org.ros.node.service.ServiceServer;
 import org.ros.node.topic.Publisher;
 import org.ros.node.topic.Subscriber;
 
@@ -54,10 +49,6 @@ public class MockDSRCDriver extends AbstractMockDriver {
   Subscriber<cav_msgs.ByteArray> outboundSub;
   final String outboundTopic = "comms/outbound_binary_msg";
 
-  //Services
-  protected ServiceServer<cav_srvs.SendMessageRequest, cav_srvs.SendMessageResponse> sendServer;
-  final String sendService = "comms/send";
-
   private final int EXPECTED_DATA_COL_COUNT = 3;
 
   private final short SAMPLE_ID_IDX = 0;
@@ -74,25 +65,15 @@ public class MockDSRCDriver extends AbstractMockDriver {
     super(connectedNode);
     // Topics
     // Published
-    recvPub = connectedNode.newPublisher("~/" + recvTopic, cav_msgs.ByteArray._TYPE);
+    recvPub = connectedNode.newPublisher("/" + recvTopic, cav_msgs.ByteArray._TYPE);
 
     // Subscribed
-    outboundSub = connectedNode.newSubscriber("~/" + outboundTopic, cav_msgs.ByteArray._TYPE);
+    outboundSub = connectedNode.newSubscriber("/" + outboundTopic, cav_msgs.ByteArray._TYPE);
     outboundSub.addMessageListener(new MessageListener<ByteArray>() {
       @Override public void onNewMessage(ByteArray byteArray) {
         log.debug("Outbound " + byteArray.getMessageType() + " message received by " + getGraphName());
       }
     });
-
-    //Services
-    //Server
-    sendServer = connectedNode.newServiceServer("~/" + sendService, cav_srvs.SendMessage._TYPE,
-      new ServiceResponseBuilder<SendMessageRequest, SendMessageResponse>() {
-        @Override public void build(SendMessageRequest sendMessageRequest,
-          SendMessageResponse sendMessageResponse) throws ServiceException {
-          log.info("Send request received by " + getGraphName() + " with contents " + sendMessageRequest);
-        }
-      });
   }
 
   @Override protected void publishData(List<String[]> data) {
@@ -168,7 +149,7 @@ public class MockDSRCDriver extends AbstractMockDriver {
   }
 
   @Override public List<String> getDriverAPI() {
-    return new ArrayList<>(Arrays.asList(recvTopic, outboundTopic, sendService));
+    return new ArrayList<>(Arrays.asList(recvTopic, outboundTopic));
   }
   
   @Override public long getPublishDelay() {

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockPinPointDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockPinPointDriver.java
@@ -17,10 +17,8 @@
 package gov.dot.fhwa.saxton.carma.mock_drivers;
 
 import org.ros.message.Time;
-import org.ros.namespace.GraphName;
 import org.ros.node.ConnectedNode;
 import org.ros.node.topic.Publisher;
-import rosgraph_msgs.Log;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,13 +82,13 @@ public class MockPinPointDriver extends AbstractMockDriver {
     // Topics
     // Published
     headingPub =
-      connectedNode.newPublisher("~/position/heading", cav_msgs.HeadingStamped._TYPE);
+      connectedNode.newPublisher("/position/heading", cav_msgs.HeadingStamped._TYPE);
     navSatFixPub =
-      connectedNode.newPublisher("~/position/nav_sat_fix", sensor_msgs.NavSatFix._TYPE);
+      connectedNode.newPublisher("/position/nav_sat_fix", sensor_msgs.NavSatFix._TYPE);
     odometryPub =
-      connectedNode.newPublisher("~/position/odometry", nav_msgs.Odometry._TYPE);
+      connectedNode.newPublisher("/position/odometry", nav_msgs.Odometry._TYPE);
     velocityPub =
-      connectedNode.newPublisher("~/position/velocity", geometry_msgs.TwistStamped._TYPE);
+      connectedNode.newPublisher("/position/velocity", geometry_msgs.TwistStamped._TYPE);
   }
 
   @Override protected void publishData(List<String[]> data) throws IllegalArgumentException {

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockRadarDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockRadarDriver.java
@@ -17,7 +17,6 @@
 package gov.dot.fhwa.saxton.carma.mock_drivers;
 
 import org.ros.message.Time;
-import org.ros.namespace.GraphName;
 import org.ros.node.ConnectedNode;
 import org.ros.node.topic.Publisher;
 import java.util.ArrayList;

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockSRXControllerDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockSRXControllerDriver.java
@@ -82,10 +82,10 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
     super(connectedNode);
     // Topics
     // Published
-    statusPub = connectedNode.newPublisher("~/control/robot_status", RobotEnabled._TYPE);
+    statusPub = connectedNode.newPublisher("/control/robot_status", RobotEnabled._TYPE);
 
     diagnosticsPub = connectedNode.newPublisher("/diagnostics", diagnostic_msgs.DiagnosticArray._TYPE);
-    enabledSrv = connectedNode.newServiceServer("~/control/enable_robotic", cav_srvs.SetEnableRobotic._TYPE,
+    enabledSrv = connectedNode.newServiceServer("/control/enable_robotic", cav_srvs.SetEnableRobotic._TYPE,
         new ServiceResponseBuilder<SetEnableRoboticRequest, SetEnableRoboticResponse>() {
           @Override
           public void build(SetEnableRoboticRequest arg0, SetEnableRoboticResponse arg1) throws ServiceException {
@@ -94,12 +94,12 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
         });
 
     // Subscribed
-    longEffortSub = connectedNode.newSubscriber("~/control/cmd_longitudinal_effort", std_msgs.Float32._TYPE);
-    subscriber = connectedNode.newSubscriber("~/control/cmd_speed", cav_msgs.SpeedAccel._TYPE);
+    longEffortSub = connectedNode.newSubscriber("/control/cmd_longitudinal_effort", std_msgs.Float32._TYPE);
+    subscriber = connectedNode.newSubscriber("/control/cmd_speed", cav_msgs.SpeedAccel._TYPE);
 
     // Services
     // Server
-    getLightsService = connectedNode.newServiceServer("~/control/get_lights", cav_srvs.GetLights._TYPE,
+    getLightsService = connectedNode.newServiceServer("/control/get_lights", cav_srvs.GetLights._TYPE,
         new ServiceResponseBuilder<cav_srvs.GetLightsRequest, cav_srvs.GetLightsResponse>() {
           @Override
           public void build(cav_srvs.GetLightsRequest request, cav_srvs.GetLightsResponse response) {
@@ -112,7 +112,7 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
             response.setStatus(lightStatus);
           }
         });
-    setLightsService = connectedNode.newServiceServer("~/control/set_lights", cav_srvs.SetLights._TYPE,
+    setLightsService = connectedNode.newServiceServer("/control/set_lights", cav_srvs.SetLights._TYPE,
         new ServiceResponseBuilder<SetLightsRequest, SetLightsResponse>() {
           @Override
           public void build(cav_srvs.SetLightsRequest request, cav_srvs.SetLightsResponse response) {

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockTruckControllerDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockTruckControllerDriver.java
@@ -23,7 +23,6 @@ import cav_srvs.SetLightsRequest;
 import cav_srvs.SetLightsResponse;
 import diagnostic_msgs.DiagnosticStatus;
 import diagnostic_msgs.KeyValue;
-import org.ros.namespace.GraphName;
 import org.ros.node.ConnectedNode;
 import org.ros.node.service.ServiceResponseBuilder;
 import org.ros.node.service.ServiceServer;
@@ -82,20 +81,20 @@ public class MockTruckControllerDriver extends AbstractMockDriver {
     // Topics
     // Published
     diagnosticsPub =
-      connectedNode.newPublisher("~/control/diagnostics", diagnostic_msgs.DiagnosticArray._TYPE);
+      connectedNode.newPublisher("/control/diagnostics", diagnostic_msgs.DiagnosticArray._TYPE);
     enabledPub =
-      connectedNode.newPublisher("~/control/robot_enabled", cav_msgs.RobotEnabled._TYPE);
+      connectedNode.newPublisher("/control/robot_enabled", cav_msgs.RobotEnabled._TYPE);
 
     // Subscribed
     longEffortSub =
-      connectedNode.newSubscriber("~/control/cmd_longitudinal_effort", std_msgs.Float32._TYPE);
+      connectedNode.newSubscriber("/control/cmd_longitudinal_effort", std_msgs.Float32._TYPE);
     subscriber =
-      connectedNode.newSubscriber("~/control/cmd_speed", cav_msgs.SpeedAccel._TYPE);
+      connectedNode.newSubscriber("/control/cmd_speed", cav_msgs.SpeedAccel._TYPE);
 
     // Services
     // Server
     getLightsService = connectedNode
-      .newServiceServer("~/control/get_lights", cav_srvs.GetLights._TYPE,
+      .newServiceServer("/control/get_lights", cav_srvs.GetLights._TYPE,
         new ServiceResponseBuilder<GetLightsRequest, GetLightsResponse>() {
           @Override public void build(GetLightsRequest request,
             GetLightsResponse response) {
@@ -109,7 +108,7 @@ public class MockTruckControllerDriver extends AbstractMockDriver {
           }
         });
     setLightsService = connectedNode
-      .newServiceServer("~/control/set_lights", cav_srvs.SetLights._TYPE,
+      .newServiceServer("/control/set_lights", cav_srvs.SetLights._TYPE,
         new ServiceResponseBuilder<SetLightsRequest, SetLightsResponse>() {
           @Override public void build(SetLightsRequest request,
             SetLightsResponse response) {


### PR DESCRIPTION
# PR Details
Modify legacy CARMA consumer nodes to use the launch file mapping instead of using Interface Manager for driver discovery.
## Description
Originally, the CARMA consumer nodes used Interface Manager to connect to different drivers. However, this feature is removed from CARMA3 design document. This PR is about removing driver discovery service call from consumer nodes. There will be a follow-up PR for modifying Interface Manager.
<!--- Describe your changes in detail -->
The interactions are removed from: GuidanceCommands, GuidanceStateHandler, LightBarManager, MessageConsumer and Platooning Plugin. The launch file is modified for mapping to correct topic names.
## Related Issue
#177
## Motivation and Context
Update CARMA legacy code to match new API requirement.
## How Has This Been Tested?
N/A
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
