### PR TITLE
Feature/docker consistent shutdown

### DIFF
--- a/configurations/cadillac_srx_2013/docker-compose-background.yml
+++ b/configurations/cadillac_srx_2013/docker-compose-background.yml
@@ -16,10 +16,10 @@
 version: '2'
 
 services:
-  carma-web:
+  web-ui:
     image: usdotfhwastol/carma-web-ui:2.8.2
     network_mode: host
-    container_name: carma-web
+    container_name: web-ui
     volumes_from: 
       - container:carma-config:ro
     volumes: 

--- a/configurations/cadillac_srx_2013/docker-compose.yml
+++ b/configurations/cadillac_srx_2013/docker-compose.yml
@@ -16,10 +16,10 @@
 version: '2'
 
 services:
-  carma:
+  platform:
     image: usdotfhwastol/carma:2.8.3
     network_mode: host
-    container_name: carma
+    container_name: platform
     volumes_from: 
       - container:carma-config:ro
     volumes:
@@ -27,8 +27,8 @@ services:
       - /opt/carma/.ros:/home/carma/.ros
       - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
     command: wait-for-it.sh localhost:11311 -- roslaunch carma saxton_cav_docker.launch
-  carma-mock-lateral-control-driver:
-    image: usdotfhwastol/carma
+  mock-lateral-control-driver:
+    image: usdotfhwastol/carma:2.8.3
     network_mode: host
     container_name: carma-mock-lateral-control-driver
     volumes_from: 

--- a/engineering_tools/carma-config
+++ b/engineering_tools/carma-config
@@ -34,10 +34,10 @@ carma-config__set() {
         echo "Clearing existing CARMA configuration instance..."
         echo "Shutting down CARMA processes..."
         local OLD_CARMA_DOCKER_FILE="`docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose.yml'`"
-        echo "$OLD_CARMA_DOCKER_FILE" | docker-compose -f - down
+        echo "$OLD_CARMA_DOCKER_FILE" | docker-compose -p carma -f - down
         echo "Shutting down CARMA background processes..."
         local OLD_CARMA_BACKGROUND_DOCKER_FILE="`docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose-background.yml'`"
-        echo "$OLD_CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -f - down
+        echo "$OLD_CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -p carma-background -f - down
         echo "Deleting old CARMA config..."
         docker rm carma-config
     fi
@@ -46,7 +46,7 @@ carma-config__set() {
     docker run --name carma-config "usdotfhwastol/carma-config:$1"
     echo "Starting usdotfhwastol/carma-config:$1 background processes..."
     local CARMA_BACKGROUND_DOCKER_FILE="`docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose-background.yml'`"
-    echo "$CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -f - up -d
+    echo "$CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -p carma-background -f - up -d
 }
 
 carma-config__edit() {

--- a/engineering_tools/carma-config
+++ b/engineering_tools/carma-config
@@ -32,21 +32,14 @@ carma-config__set() {
 
     if docker container inspect carma-config > /dev/null; then
         echo "Clearing existing CARMA configuration instance..."
-        echo "Shutting down CARMA processes..."
-        local OLD_CARMA_DOCKER_FILE="`docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose.yml'`"
-        echo "$OLD_CARMA_DOCKER_FILE" | docker-compose -p carma -f - down
-        echo "Shutting down CARMA background processes..."
-        local OLD_CARMA_BACKGROUND_DOCKER_FILE="`docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose-background.yml'`"
-        echo "$OLD_CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -p carma-background -f - down
+        carma-config__stop
         echo "Deleting old CARMA config..."
         docker rm carma-config
     fi
 
     echo "Setting usdotfhwastol/carma-config:$1 as current CARMA configuration instance..."
     docker run --name carma-config "usdotfhwastol/carma-config:$1"
-    echo "Starting usdotfhwastol/carma-config:$1 background processes..."
-    local CARMA_BACKGROUND_DOCKER_FILE="`docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose-background.yml'`"
-    echo "$CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -p carma-background -f - up -d
+    carma-config__start
 }
 
 carma-config__edit() {
@@ -92,7 +85,9 @@ carma-config__list_local() {
 carma-config__list_remote() {
     echo "Remotely available images from usdotfhwastol Dockerhub: "
     echo ""
-    wget -q https://registry.hub.docker.com/v1/repositories/usdotfhwastol/carma-config/tags -O -  | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print "usdotfhwastol/carma-config:"$3}'
+    wget -q https://registry.hub.docker.com/v1/repositories/usdotfhwastol/carma-config/tags -O -  | \
+    sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | \
+    awk -F: '{print "usdotfhwastol/carma-config:"$3}'
 }
 
 carma-config__install() {
@@ -110,20 +105,44 @@ carma-config__install() {
     echo "$CARMA_BACKGROUND_DOCKER_FILE" | docker-compose -f - pull
 }
 
+carma-config__start() {
+    echo "Starting CARMA background processes..."
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/docker-compose-background.yml' | \
+    docker-compose -f - -p carma-background up -d
+}
+
+carma-config__stop() {
+    echo "Shutting down CARMA processes..."
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/docker-compose.yml' | \
+    docker-compose -f - -p carma down
+
+    echo "Shutting down CARMA background processes..."
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/docker-compose-background.yml' | \
+    docker-compose -f - -p carma-background down
+}
+
 carma-config__status() {
     local CURRENT_IMAGE=`docker container inspect --format='{{.Config.Image}}' carma-config`
     echo "Current configuration is loaded from image: $CURRENT_IMAGE"
     echo ""
     echo "  -- docker-compose.yml:"
-    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose.yml'
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/docker-compose.yml'
     echo "  -- docker-compose-background.yml:"
-    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/docker-compose-background.yml'
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/docker-compose-background.yml'
     echo "  -- saxton_cav.launch:"
-    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/saxton_cav.launch'
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/saxton_cav.launch'
     echo "  -- carma.config.js:"
-    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/carma.config.js'
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/carma.config.js'
     echo "  -- saxton_cav.urdf:"
-    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c 'cat /opt/carma/vehicle/saxton_cav.urdf'
+    docker run --rm --volumes-from carma-config:ro --entrypoint sh busybox:latest -c \
+    'cat /opt/carma/vehicle/saxton_cav.urdf'
 }
 
 carma-config__help() {
@@ -144,6 +163,9 @@ Please enter one of the following commands:
   inspect - Open a shell inside the current configuration storage with r/o
             permissions
   reset - Restore a configuration to its default state
+  start - Start the CARMA platform's background processes. Platform must still
+          be launched from Web UI
+  stop - Stop the CARMA platform and it's background processes.
   help - Display this information"
 HELP
 }


### PR DESCRIPTION
# PR Details

## Description

Enhances the reliability of docker-compose down by using project name settings to consistently refer to containers instead of relying on current directory.

## Motivation and Context

docker-compose by default uses the current directory name as context when launching or shutting down a stack. This causes inconsistencies when commands are not always run from the same folder.

## How Has This Been Tested?

Tested locally interacting with Dockerized CARMA system

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation. **(N/a)**
- [ ] I have updated the documentation accordingly. **(N/a)**
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes. **(N/a)**
- [ ] All new and existing tests passed. **(N/a)**
