### PR TITLE
Add platooning demo configuration

### DIFF
--- a/configurations/cadillac_srx_2013_platooning_demo/.dockerignore
+++ b/configurations/cadillac_srx_2013_platooning_demo/.dockerignore
@@ -1,0 +1,3 @@
+HostVehicleParams.yaml
+build-image.sh
+Dockerfile

--- a/configurations/cadillac_srx_2013_platooning_demo/Dockerfile
+++ b/configurations/cadillac_srx_2013_platooning_demo/Dockerfile
@@ -1,0 +1,39 @@
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+
+# GENERIC Template for CARMA Configuration Dockerfiles
+# Do not invoke directly, symlink into configuration folders below and invoke from there
+
+FROM busybox:latest
+
+ARG BUILD_DATE="NULL"
+ARG VERSION="NULL"
+ARG VCS_REF="NULL"
+ARG CONFIG_NAME="carma-config:unspecified"
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name=${CONFIG_NAME}
+LABEL org.label-schema.description="System configuration data for the CARMA Platform"
+LABEL org.label-schema.vendor="Leidos"
+LABEL org.label-schema.version=${VERSION}
+LABEL org.label-schema.url="https://highways.dot.gov/research/research-programs/operations/CARMA"
+LABEL org.label-schema.vcs-url="https://github.com/usdot-fhwa-stol/CARMAPlatform"
+LABEL org.label-schema.vcs-ref=${VCS_REF}
+LABEL org.label-schema.build-date=${BUILD_DATE}
+
+ADD . /root/vehicle
+VOLUME /opt/carma/vehicle
+
+CMD  cp /root/vehicle/* /opt/carma/vehicle

--- a/configurations/cadillac_srx_2013_platooning_demo/HostVehicleParams.yaml
+++ b/configurations/cadillac_srx_2013_platooning_demo/HostVehicleParams.yaml
@@ -1,0 +1,30 @@
+# HostVehicleParams.yaml
+# Defines the ros parameters which define the host vehicle's characteristics
+
+# String: Host vehicle color
+vehicle_color: 'GREEN'
+
+# Double: Host vehicle height
+# Units: Meters
+vehicle_height: 1.7018
+
+# String: Host vehicle’s Unique ID that will be used in mobility messages.
+vehicle_id: 'DOT-GREEN'
+
+# Double: Host vehicle length
+# Units: Meters
+vehicle_length: 4.8768
+
+# String: Host vehicle make
+vehicle_make: 'Cadillac'
+
+# String: Host vehicle model
+vehicle_model: 'SRX'
+
+# Double: Host vehicle width
+# Units: Meters
+vehicle_width: 2.1336
+
+# Integer: Host vehicle year
+# Units: Year
+vehicle_year: 2013

--- a/configurations/cadillac_srx_2013_platooning_demo/build-image.sh
+++ b/configurations/cadillac_srx_2013_platooning_demo/build-image.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+#
+# GENERIC Build Script for CARMA Configuration Images
+#
+# Do not run this script itself, rather symlink this script into the individual
+# configuration folders below and invoke it there to build the appropriate config
+# image using docker build. Automatically acquires folder name and system version
+# and passes neessary data into the docker build process.
+
+USERNAME=usdotfhwastol
+IMAGE=carma-config
+cd "$(dirname "$0")"
+DIR_NAME=${PWD##*/}
+CONFIG_NAME=`echo $DIR_NAME | sed 's/_/-/g'`
+
+echo ""
+echo "##### CARMA $CONFIG_NAME Configuration Docker Image Build Script #####"
+echo ""
+
+
+if [[ -z "$1" ]]; then
+    TAG="$("../../engineering_tools/get-carma-version.sh")-$CONFIG_NAME"
+else
+    TAG="$1-$CONFIG_NAME"
+fi
+
+echo "Building docker image for CARMA Configuration version: $TAG"
+echo "Final image name: $USERNAME/$IMAGE:$TAG"
+
+docker build --no-cache -t $USERNAME/$IMAGE:$TAG \
+    --build-arg VERSION="$TAG" \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    --build-arg CONFIG_NAME="carma-config:$CONFIG_NAME" \
+    --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .
+
+echo ""
+echo "##### CARMA $CONFIG_NAME Docker Image Build Done! #####"

--- a/configurations/cadillac_srx_2013_platooning_demo/carma.config.js
+++ b/configurations/cadillac_srx_2013_platooning_demo/carma.config.js
@@ -1,0 +1,56 @@
+/***
+* Source: https://www.kenneth-truyers.net/2013/04/27/javascript-namespaces-and-modules/
+***/
+
+'use strict';
+
+// Create the root namespace and making sure we're not overwriting it
+var CarmaJS = CarmaJS || {};
+
+// Create a general purpose namespace method
+// This will allow us to create namespace a bit easier
+CarmaJS.registerNamespace = function (namespace) {
+    var nsparts = namespace.split(".");
+    var parent = CarmaJS;
+
+    // we want to be able to include or exclude the root namespace
+    // So we strip it if it's in the namespace
+    if (nsparts[0] === "CarmaJS") {
+        nsparts = nsparts.slice(1);
+    }
+
+    // loop through the parts and create
+    // a nested namespace if necessary
+    for (var i = 0; i < nsparts.length; i++) {
+        var partname = nsparts[i];
+        // check if the current parent already has
+        // the namespace declared, if not create it
+        if (typeof parent[partname] === "undefined") {
+            parent[partname] = {};
+        }
+        // get a reference to the deepest element
+        // in the hierarchy so far
+        parent = parent[partname];
+    }
+    // the parent is now completely constructed
+    // with empty namespaces and can be used.
+    return parent;
+};
+
+CarmaJS.registerNamespace("CarmaJS.Config");
+
+CarmaJS.Config = (function () {
+        //Private variables
+        var ip = '192.168.88.10'; //'192.168.88.10'; 192.168.32.146;
+
+        //Private methods
+        //Creating functions to prevent access by reference to private variables
+        var getIP = function() {
+            return ip;
+        };
+
+        //Public API
+        return {
+            getIP: getIP
+        };
+})();

--- a/configurations/cadillac_srx_2013_platooning_demo/docker-compose-background.yml
+++ b/configurations/cadillac_srx_2013_platooning_demo/docker-compose-background.yml
@@ -1,0 +1,37 @@
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# Docker Compose Spec Version
+version: '2'
+
+services:
+  web-ui:
+    image: usdotfhwastol/carma-web-ui:2.8.2
+    network_mode: host
+    container_name: web-ui
+    volumes_from: 
+      - container:carma-config:ro
+    volumes: 
+      - /var/run/docker.sock:/var/run/docker.sock 
+    restart: always
+  roscore:
+    image: usdotfhwastol/carma-base:2.8.3
+    network_mode: host
+    container_name: roscore
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/.ros:/home/carma/.ros
+    restart: always
+    command: roscore

--- a/configurations/cadillac_srx_2013_platooning_demo/docker-compose.yml
+++ b/configurations/cadillac_srx_2013_platooning_demo/docker-compose.yml
@@ -71,9 +71,6 @@ services:
       - /opt/carma/.ros:/home/carma/.ros
       - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
     command: wait-for-it.sh localhost:11311 -- roslaunch srx_objects srx_objects_socketcan.launch remap_ns:=/saxton_cav/drivers srx_objects_can_device:=can0
-      <arg name="k_p" default="0.1" />
-    <arg name="k_i" default="0.01" />
-    <arg name="k_d" default="0.005" />
   cadillac-srx-2013-controller-driver:
     image: usdotfhwastol/carma-cadillac-srx-2013-controller-driver:1.0.2
     container_name: carma-cadillac-srx-2013-controller-driver

--- a/configurations/cadillac_srx_2013_platooning_demo/docker-compose.yml
+++ b/configurations/cadillac_srx_2013_platooning_demo/docker-compose.yml
@@ -1,0 +1,98 @@
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# Docker Compose Spec Version
+version: '2'
+
+services:
+  platform:
+    image: usdotfhwastol/carma:2.8.3
+    network_mode: host
+    container_name: platform
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
+    command: wait-for-it.sh localhost:11311 -- roslaunch carma saxton_cav_docker.launch
+  mock-lateral-control-driver:
+    image: usdotfhwastol/carma:2.8.3
+    network_mode: host
+    container_name: carma-mock-lateral-control-driver
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
+    command: wait-for-it.sh localhost:11311 --  rosrun carma lateral_control_driver gov.dot.fhwa.saxton.carma.lateralcontroldriver.LateralControlDriver
+  cohda_dsrc_driver:
+    image: usdotfhwastol/carma-cohda-dsrc-driver:1.0.0
+    container_name: carma-cohda-dsrc-driver
+    network_mode: host
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
+    command: wait-for-it.sh localhost:11311 -- roslaunch dsrc_driver dsrc_node.launch remap_ns:=/saxton_cav/drivers
+  cadillac-srx-2013-can-driver:
+    image: usdotfhwastol/carma-cadillac-srx-2013-can-driver:1.0.1
+    container_name: carma-cadillac-srx-2013-can-driver
+    network_mode: host
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
+    command: wait-for-it.sh localhost:11311 -- roslaunch srx_can_driver srx_can_driver_socketcan.launch remap_ns:=/saxton_cav/drivers srx_can_can_device:=can2
+  cadillac-srx-2013-objects-driver:
+    image: usdotfhwastol/carma-cadillac-srx-2013-objects-driver:1.0.2
+    container_name: carma-cadillac-srx-2013-objects-driver
+    network_mode: host
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
+    command: wait-for-it.sh localhost:11311 -- roslaunch srx_objects srx_objects_socketcan.launch remap_ns:=/saxton_cav/drivers srx_objects_can_device:=can0
+      <arg name="k_p" default="0.1" />
+    <arg name="k_i" default="0.01" />
+    <arg name="k_d" default="0.005" />
+  cadillac-srx-2013-controller-driver:
+    image: usdotfhwastol/carma-cadillac-srx-2013-controller-driver:1.0.2
+    container_name: carma-cadillac-srx-2013-controller-driver
+    network_mode: host
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
+    command: wait-for-it.sh localhost:11311 -- roslaunch srx_controller srx_controller.launch remap_ns:=/saxton_cav/drivers srx_controller_can_device:=can1 k_p:=0.1 k_i:=0.01 k_d:=0.005
+  torc-pinpoint-driver:
+    image: usdotfhwastol/carma-torc-pinpoint-driver:1.0.7
+    container_name: carma-torc-pinpoint-driver
+    network_mode: host
+    volumes_from: 
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/HostVehicleParams.yaml:/opt/carma/params/HostVehicleParams.yaml
+    command: wait-for-it.sh localhost:11311 -- roslaunch pinpoint pinpoint.launch remap_ns:=/saxton_cav/drivers

--- a/configurations/cadillac_srx_2013_platooning_demo/drivers.launch
+++ b/configurations/cadillac_srx_2013_platooning_demo/drivers.launch
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<!--
+  Copyright (C) 2018-2019 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+	drivers.launch
+
+This file is used for vehicle configurations. The arguments from saxton_cav.launch should pass on to saxton_cav_src.launch, which should then pass those arguments to this file. The arguments in the saxton_cav.launch file will override all of the default values of the arguments being passed, so you should be making changes to the saxton_cav.launch to configure it to your vehicle. 
+
+If not using simulated drivers they are activated if the respective mock arguments being passed in are false. These lines below activate the respective actual driver if the respective mock argument being passed is false.
+
+-->
+
+<launch>
+
+  <!-- Directory of Parameter Files -->
+  <arg name="CARMA_DIR" default="$(find carma)" doc="The path of the package directory"/>
+  <arg name="PARAM_DIR" default="$(arg CARMA_DIR)/launch/params" doc="Directory of yaml parameter files"/>
+
+  <!-- Simulation Usage -->
+  <arg name="mock_can"            	default="true" doc="True if using a simulated can driver"/>
+  <arg name="mock_dsrc"           	default="true" doc="True if using a simulated dsrc driver"/>
+  <arg name="mock_srx_controller" 	default="true" doc="True if using a simulated srx controller driver"/>
+  <arg name="mock_pinpoint"       	default="true" doc="True if using a simulated pinpoint driver"/>
+  <arg name="mock_radar"          	default="true" doc="True if using a simulated radar driver"/>
+  <arg name="mock_lateral_controller"   default="true" doc="True if using a simulated lateral controller"/>
+
+  <!-- DSRC OBU Driver Node -->
+  <include unless="$(arg mock_dsrc)" file="$(find dsrc_driver)/launch/dsrc_node.launch"/>
+      
+  <!-- PinPoint Driver Node -->
+  <include unless="$(arg mock_pinpoint)" file="$(find pinpoint)/launch/pinpoint.launch"/>
+
+  <!-- SRX CAN Driver Node -->
+  <include unless="$(arg mock_can)" file="$(find srx_can_driver)/launch/srx_can_driver_socketcan.launch">
+    <arg name="srx_can_can_device" value="can2" />
+  </include>
+
+  <!--SRX Controller Driver Node-->
+  <include unless="$(arg mock_srx_controller)" file="$(find srx_controller)/launch/srx_controller.launch">
+
+    <!-- Low Speed Values -->
+    <arg name="k_p" value="0.5" />
+    <arg name="k_i" value="0.003" />
+    <arg name="k_d" value="0.04" />
+    <!-- HighSpeed Values -->
+    <!--
+    <arg name="k_p" default="0.1" />
+    <arg name="k_i" default="0.01" />
+    <arg name="k_d" default="0.005" />
+    -->
+    <arg name="srx_controller_can_device" value="can1"/>
+  </include>
+      
+  <!-- SRX Radar Driver Node -->
+  <include unless="$(arg mock_radar)" file="$(find srx_objects)/launch/srx_objects_socketcan.launch">
+    <arg name="srx_objects_can_device" value="can0"/>
+  </include>
+	
+</launch>

--- a/configurations/cadillac_srx_2013_platooning_demo/saxton_cav.launch
+++ b/configurations/cadillac_srx_2013_platooning_demo/saxton_cav.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!--
+  Copyright (C) 2018-2019 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+	saxton_cav.launch
+
+  A the ros launch file for the STOL CAV Prototype ROS Network.
+  Launches all the needed ros nodes and sets up the parameter server.
+  Also sets up all static transforms used by tf2 within the system.
+
+  File is meant to be run on a configured vehicle pc.
+  Applies the appropriate arguments to the saxton_cav_src.launch file to launch on a vehicle
+  
+  Note: To ensure all ros processes are killed before launch use
+  pkill -f ros
+-->
+<launch>
+
+  <!-- Set Environment Variables -->
+  <env name="ROS_IP" value="192.168.88.10"/>
+
+  <!-- Override Required Paths -->
+  <arg name="CARMA_DIR" default="/opt/carma" doc="The path of the package directory"/>
+  <arg name="PARAM_DIR" default="$(arg CARMA_DIR)/params" doc="Directory of yaml parameter files"/>
+  <arg name="URDF_FILE" default="$(arg CARMA_DIR)/urdf/saxton_cav.urdf" doc="Path to the vehicle's URDF file"/>
+  <arg name="DATA_DIR"  default="$(arg CARMA_DIR)/app/mock_data" doc="Directory of driver simulation"/>
+  <arg name="SCRIPTS_DIR" default="$(arg CARMA_DIR)/app/engineering_tools" doc="The directory containing scripts for execution"/>
+  <arg name="LAUNCH_DIR" default="$(arg CARMA_DIR)/app/bin/share/carma" doc="Directory containing additional carma launch files such as driver.launch"/>
+  <arg name="log_config" default="$(arg PARAM_DIR)/log-config.properties" doc="The location of the logging config file"/>
+
+  <!-- Disable Mock Drivers -->
+  <arg name="mock_can"            	default="false" doc="True if using a simulated can driver"/>
+  <arg name="mock_dsrc"           	default="false" doc="True if using a simulated dsrc driver"/>
+  <arg name="mock_srx_controller" 	default="false" doc="True if using a simulated srx controller driver"/>
+  <arg name="mock_pinpoint"       	default="false" doc="True if using a simulated pinpoint driver"/>
+  <arg name="mock_radar"          	default="false" doc="True if using a simulated radar driver"/>
+  <arg name="mock_lateral_controller"   default="true" doc="True if using a simulated lateral controller"/>
+
+  <!-- Rosbag Flag -->
+  <arg name="use_rosbag" default="true" doc="Record a rosbag for the to 26 demo"/>
+
+  <!-- Include the detailed launch file and pass in new arguments -->
+  <include file="$(find carma)/saxton_cav_src.launch" pass_all_args="true"/>
+</launch>

--- a/configurations/cadillac_srx_2013_platooning_demo/saxton_cav.urdf
+++ b/configurations/cadillac_srx_2013_platooning_demo/saxton_cav.urdf
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<!--
+  Copyright (C) 2018-2019 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!-- Green Cadillac Robot Description File
+    This file defines the static transformations of the CAV platform operating on the green cadillac.
+    These are only example values at this time. This is to test if it works
+-->
+<robot name="saxton_cav_srx">
+  <!-- Frames -->
+  <link name="base_link" /> <!-- Back Axle -->
+  <link name="host_vehicle"/> <!-- Bounding box center of vehicle (used in BSM)-->
+  <link name="aabb_center"> <!-- Center of the car's axis aligned bounding box -->
+      <!-- Simple visual to draw box around car transforms  in rviz -->
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <box size="4.88 1.5 2.2" />
+      </geometry>
+      <material name="Green">
+        <color rgba="0.0 1.0 0.0 1.0"/>
+      </material>
+    </visual>
+  </link>
+  <link name="vehicle_front" /> <!-- Center of vehicle grill -->
+  <link name="pinpoint" /> <!-- Position Sensor (Accounting for internal transforms) -->
+  <!-- Radars -->
+  <link name="f_lrr_frame"/> <!-- Front Long Range Radar -->
+  <link name="rf_srr_frame"/> <!-- Right Front Short Range Radar -->
+  <link name="lf_srr_frame"/> <!-- Left Front Short Range Radar -->
+  <link name="r_srr_frame"/> <!-- Right Short Range Radar -->
+  <!-- Cameras -->
+  <link name="vision_frame"/> <!-- Forward facing camera -->
+
+   <!-- base_link -> host_vehicle Transform -->
+  <joint name="base_link_to_host_vehicle" type="fixed">
+    <parent link="base_link" />
+    <child link="host_vehicle" />
+    <!-- Arguments (x y z roll pitch yaw) -->
+    <!-- Units: Meters and Rad-->
+    <origin xyz="1.524 0 -0.3556" rpy="3.14159265359 0 0" />
+  </joint>
+
+  <!-- host_vehicle -> aabb_center Transform -->
+  <joint name="host_vehicle_to_aabb_center" type="fixed">
+    <parent link="host_vehicle" />
+    <child link="aabb_center" />
+    <!-- Arguments (x y z roll pitch yaw) -->
+    <!-- Units: Meters and Rad-->
+    <origin xyz="0 0 -1.1" rpy="3.14159265359 0 0" />
+  </joint>
+
+  <!-- host_vehicle -> vehicle_front Transform vehicle_front is FLU-->
+  <joint name="host_vehicle_to_vehicle_front" type="fixed">
+    <parent link="host_vehicle" />
+    <child link="vehicle_front" />
+    <origin xyz="2.4384 0 0" rpy="3.14159265359 0 0" />
+  </joint>
+
+  <!--base_link is center of rear axle FLU oriented x down the longitudinal axis of the vehicle-->
+  <joint name="base_link_pinpoint" type="fixed">
+    <parent link="base_link" />
+    <child link="pinpoint" />
+    <origin xyz="0 0 0" rpy="3.14159265359 0 0" />
+  </joint>
+
+  <!-- base_link -> f_lrr_frame Transform -->
+  <joint name="rear_link_f_lrr_frame" type="fixed">
+    <parent link="base_link"/>
+    <child link="f_lrr_frame"/>
+    <origin xyz="3.7 0 0.43" rpy="0 0 0" />
+  </joint>
+
+  <!-- base_link -> rf_srr_frame Transform -->
+  <joint name="rear_link_rf_srr_frame" type="fixed">
+    <parent link="base_link"/>
+    <child link="rf_srr_frame"/>
+    <origin xyz="3.73 -0.39 0.2" rpy="0 0 -0.09" />
+  </joint>
+
+  <!-- base_link -> lf_srr_frame Transform -->
+  <joint name="rear_link_lf_srr_frame" type="fixed">
+    <parent link="base_link"/>
+    <child link="lf_srr_frame"/>
+    <origin xyz="3.73 0.39 0.2" rpy="0 0 0.09" />
+  </joint>
+
+  <!-- base_link -> r_srr_frame Transform -->
+  <joint name="rear_link_r_srr_frame" type="fixed">
+    <parent link="base_link"/>
+    <child link="r_srr_frame"/>
+    <origin xyz="-0.95 0.19 0.31" rpy="0 0 3.1" />
+  </joint>
+
+  <!-- base_link -> vision_frame Transform -->
+  <joint name="rear_link_vision_frame" type="fixed">
+    <parent link="base_link"/>
+    <child link="vision_frame"/>
+    <origin xyz="1.94 -0.1 1.07" rpy="0 0 0" />
+  </joint>
+</robot>


### PR DESCRIPTION
This adds a platooning demo configuration to the configurations folder for use on the colonial farm road demo run. It modifies the docker compose file to set the pid parameters to the old high speed values see line 87 in compose file and drivers.launch comment to confirm values. 

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
