### PR TITLE
Fix edit command

### DIFF
--- a/engineering_tools/carma
+++ b/engineering_tools/carma
@@ -54,7 +54,7 @@ carma-config__edit() {
     fi
 
     echo "Opening shell inside carma-config container with read/write privileges..."
-    docker run -it --rm --volumes-from carma-config usdotfhwastol/carma-base:latest
+    docker run -it --rm --volumes-from carma-config usdotfhwastol/carma-base:latest bash
 }
 
 carma-config__inspect() {
@@ -65,7 +65,7 @@ carma-config__inspect() {
     fi
 
     echo "Opening shell inside carma-config container with read-only privileges..."
-    docker run -it --rm --volumes-from carma-config:ro usdotfhwastol/carma-base:latest
+    docker run -it --rm --volumes-from carma-config:ro usdotfhwastol/carma-base:latest bash
 }
 
 carma-config__reset() {


### PR DESCRIPTION
# PR Details
Missing "bash" command at end causes edit and inspect command to do nothing.

## Description

Quick hotfix to correct error introduced by revisions of carma-base that require explicit invocation of bash to spawn a shell inside the CARMA base container.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
