### PR TITLE
Added mock topic for light bar status and updated remote_install script

### DIFF
--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/CarmaVersion.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/CarmaVersion.java
@@ -38,7 +38,7 @@ public class CarmaVersion {
         String name =       "Carma Platform";
         int major =         2;
         int intermediate =  8;
-        int minor =         1;
+        int minor =         4;
         // Don't touch this, automatically updated:
         int build = 0;
         String suffix = "";

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockSRXControllerDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockSRXControllerDriver.java
@@ -30,6 +30,7 @@ import org.ros.node.topic.Publisher;
 import org.ros.node.topic.Subscriber;
 
 import cav_msgs.RobotEnabled;
+import cav_msgs.LightBarStatus; //MF 02/2019 Added Light Bar Status Topic
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +51,7 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
   // Published
   protected final Publisher<diagnostic_msgs.DiagnosticArray> diagnosticsPub;
   protected Publisher<RobotEnabled> statusPub;
-  protected final ServiceServer<SetEnableRoboticRequest, SetEnableRoboticResponse> enabledSrv;
+  protected Publisher<LightBarStatus> lightBarStatusPub; //MF 02/2019
 
   // Subscribed
   protected final Subscriber<std_msgs.Float32> longEffortSub;
@@ -58,6 +59,7 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
 
   // Services
   // Server
+  protected final ServiceServer<SetEnableRoboticRequest, SetEnableRoboticResponse> enabledSrv;
   protected final ServiceServer<GetLightsRequest, GetLightsResponse> getLightsService;
   protected final ServiceServer<cav_srvs.SetLightsRequest, cav_srvs.SetLightsResponse> setLightsService;
 
@@ -83,6 +85,7 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
     // Topics
     // Published
     statusPub = connectedNode.newPublisher("/control/robot_status", RobotEnabled._TYPE);
+    lightBarStatusPub = connectedNode.newPublisher("/control/light_bar_status", LightBarStatus._TYPE); //MF 02/2019
 
     diagnosticsPub = connectedNode.newPublisher("/diagnostics", diagnostic_msgs.DiagnosticArray._TYPE);
     enabledSrv = connectedNode.newServiceServer("/control/enable_robotic", cav_srvs.SetEnableRobotic._TYPE,
@@ -135,6 +138,16 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
       // Make messages
       diagnostic_msgs.DiagnosticArray diagMsg = diagnosticsPub.newMessage();
       RobotEnabled statusMsg = statusPub.newMessage();
+      LightBarStatus lightBarStatusMsg = lightBarStatusPub.newMessage(); //MF 02/2019
+
+      // //MF 02/2019: Build Light Bar Status Message //Right Arrow
+      // GREEN FLASH
+      lightBarStatusMsg.setGreenFlash(LightBarStatus.ON);
+      lightBarStatusMsg.setLeftArrow(LightBarStatus.OFF);
+      lightBarStatusMsg.setRightArrow(LightBarStatus.OFF);
+      lightBarStatusMsg.setGreenSolid(LightBarStatus.OFF);
+      lightBarStatusMsg.setFlash(LightBarStatus.OFF);
+      lightBarStatusMsg.setTakedown(LightBarStatus.OFF);
 
       // Build RobotEnabled Message
       statusMsg.setBrakeDecel(Double.parseDouble(elements[BRAKE_DECEL_IDX]));
@@ -167,6 +180,7 @@ public class MockSRXControllerDriver extends AbstractMockDriver {
       // Publish Data
       diagnosticsPub.publish(diagMsg);
       statusPub.publish(statusMsg);
+      lightBarStatusPub.publish(lightBarStatusMsg); //MF 02/2019
     }
   }
 

--- a/engineering_tools/remote_install.bash
+++ b/engineering_tools/remote_install.bash
@@ -117,7 +117,7 @@ PARAMS_DIR="${LOCAL_CARMA_DIR}/carmajava/launch/params"
 ROUTES_DIR="${LOCAL_CARMA_DIR}/carmajava/route/src/test/resources/routes"
 URDF_DIR="${LOCAL_CARMA_DIR}/carmajava/launch/urdf"
 MOCK_DATA_DIR="${LOCAL_CARMA_DIR}/carmajava/mock_drivers/src/test/data"
-WEBSITE_DIR="${LOCAL_CARMA_DIR}/website"
+WEBSITE_DIR="${CATKIN_WS}/src/CARMAWebUi/website"
 SCRIPTS_DIR="${LOCAL_CARMA_DIR}/engineering_tools"
 
 # Define paths needed on vehicle pc


### PR DESCRIPTION
# PR Details

## Description

## Related Issue
This is an enhancement for Sprint 7 to include the light bar status on the UI. This entails having a topic from SRXController to publish the light bar status. 

During development, there are 2 lightbars back and rear. But since you can only set both at this time, we based the topic on the front lightbar status.

## Motivation and Context
NA

## How Has This Been Tested?
Tested the initial topic published by carma. See pic attached. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
