### PR TITLE
Add raw can data to rosbag exclusion list

### DIFF
--- a/carmajava/launch/saxton_cav_src.launch
+++ b/carmajava/launch/saxton_cav_src.launch
@@ -485,9 +485,9 @@
         <arg name="port" value="9090"/> <!-- The default port for rosbridge is 9090 -->
       </include>
     </group>
-    <!-- Record Rosbag of all topics excluding /rosout since that only contains logs -->
+    <!-- Record Rosbag of all topics excluding /rosout and CAN messages since they may contain sensetive data -->
     <node pkg="rosbag" type="record" name="rosbag_node"
-      args="record -o /opt/carma/logs/ -a -x '/rosout(.*)'"
+      args="record -o /opt/carma/logs/ -a -x '/rosout(.*)|(.*)/received_messages|(.*)/sent_messages'"
       if="$(arg use_rosbag)" />
   </group>
 </launch>


### PR DESCRIPTION
# PR Details
This removes received_messages and sent_messages topics from rosbags by default
On current vehicles they match to this
```   
/saxton_cav/drivers/can0/received_messages                                      
/saxton_cav/drivers/can1/received_messages                                            
/saxton_cav/drivers/can1/sent_messages                                 
/saxton_cav/drivers/can2/received_messages

```
## Description

It is necessary to remove raw CAN data from default rosbag recording to ensure generated bags do not contain sensitive vehicle manufacturer information. 

## How Has This Been Tested?

Tested using the updated rosbag command on a subset of normal carma topics
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
