### PR TITLE
Fix issue #200

### DIFF
--- a/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/util/GuidanceRouteService.java
+++ b/carmajava/guidance/src/main/java/gov/dot/fhwa/saxton/carma/guidance/util/GuidanceRouteService.java
@@ -160,9 +160,6 @@ public class GuidanceRouteService implements RouteService {
 
   @Override
   public SpeedLimit getSpeedLimitAtLocation(double location) {
-    if (location > limits.last().getLimit()) {
-      return limits.last();
-    }
 
     for (SpeedLimit limit : limits) {
       if (limit.getLocation() >= location) {
@@ -171,7 +168,7 @@ public class GuidanceRouteService implements RouteService {
     }
 
     // Should be unreachable
-    return null;
+    return limits.last();
   }
 
   @Override

--- a/carmajava/platooning/src/main/java/gov/dot/fhwa/saxton/carma/plugins/platooning/CandidateFollowerState.java
+++ b/carmajava/platooning/src/main/java/gov/dot/fhwa/saxton/carma/plugins/platooning/CandidateFollowerState.java
@@ -80,15 +80,17 @@ public class CandidateFollowerState implements IPlatooningState {
             List<SpeedLimit> mergedLimits = new LinkedList<SpeedLimit>();
             SpeedLimit limit_buffer = null;
             for (SpeedLimit limit : trajLimits) {
+                // Create new object to prevent speed limit modification
+                SpeedLimit followedLimit = new SpeedLimit(limit.getLocation(), limit.getLimit());
                 // Merge segments with same speed
                 if (limit_buffer == null) {
-                    limit_buffer = limit;
+                    limit_buffer = followedLimit;
                 } else {
-                    if (Math.abs(limit_buffer.getLimit() - limit.getLimit()) < SPEED_EPSILON) {
-                        limit_buffer.setLocation(limit.getLocation());
+                    if (Math.abs(limit_buffer.getLimit() - followedLimit.getLimit()) < SPEED_EPSILON) {
+                        limit_buffer.setLocation(followedLimit.getLocation());
                     } else {
                         mergedLimits.add(limit_buffer);
-                        limit_buffer = limit;
+                        limit_buffer = followedLimit;
                     }
                 }
             }


### PR DESCRIPTION
# PR Details
Fix for Issue #200 

Still needs to be tested on the vehicle, but put up for review since it seems pretty clear cut. 
## Description

The getSpeedLimitAtLocation function in GuidanceRouteService was returning the incorrect limit when the speed limit value dropped below the current downtrack distance value. 

Additionally, the platooning plugin was inadvertently modifying the speed limits on the route. 
## Related Issue
#200 

## Motivation and Context

No exceptions should be thrown during normal operation

## How Has This Been Tested?

Java tests pass on CircleCi

Still needs to be tested on vehicle

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
