### PR TITLE
Sanity checks for strategy strings received in mobility messages

### DIFF
--- a/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/ExecutionState.java
+++ b/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/ExecutionState.java
@@ -44,8 +44,8 @@ public class ExecutionState implements ICooperativeMergeState {
   protected static final double MAX_TARGET_SPEED = 35.0; // m/s - a little over 75 mph
   protected static final double MIN_ACCEL = -2.0; // m/s^2 - trying to keep it smooth regardless of vehicle type
   protected static final double MAX_ACCEL = 2.0;  // m/s^2
-  protected static final double MIN_TARGET_STEER = -1.0; //currently not used; what units? what meaning?
-  protected static final double MAX_TARGET_STEER = 1.0; //currently not used; what units? what meaning?
+  protected static final double MIN_TARGET_STEER = -1.0; //radians; currently not used since v2 steering is manual
+  protected static final double MAX_TARGET_STEER = 1.0; //radians; currently not used since v2 steering is manual
 
   protected final CooperativeMergePlugin   plugin;
   protected final ILogger        log;

--- a/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/ExecutionState.java
+++ b/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/ExecutionState.java
@@ -39,7 +39,14 @@ import gov.dot.fhwa.saxton.carma.rosutils.MobilityHelper;
  * Speed and steering commands received from an rsu are sent to the complex maneuver for execution.
  */
 public class ExecutionState implements ICooperativeMergeState {
-  
+
+  protected static final double MIN_TARGET_SPEED = 0.5; // m/s - if traffic is heavy, a slow speed may be okay
+  protected static final double MAX_TARGET_SPEED = 35.0; // m/s - a little over 75 mph
+  protected static final double MIN_ACCEL = -2.0; // m/s^2 - trying to keep it smooth regardless of vehicle type
+  protected static final double MAX_ACCEL = 2.0;  // m/s^2
+  protected static final double MIN_TARGET_STEER = -1.0; //currently not used; what units? what meaning?
+  protected static final double MAX_TARGET_STEER = 1.0; //currently not used; what units? what meaning?
+
   protected final CooperativeMergePlugin   plugin;
   protected final ILogger        log;
   protected final PluginServiceLocator pluginServiceLocator;
@@ -141,6 +148,16 @@ public class ExecutionState implements ICooperativeMergeState {
     double targetSpeed = Double.parseDouble(params.get(0));
     double maxAccel = Double.parseDouble(params.get(1));
     double targetSteer = Double.parseDouble(params.get(2));
+
+    //do a sanity check on the received values
+    if (targetSpeed < MIN_TARGET_SPEED  ||  targetSpeed > MAX_TARGET_SPEED  ||
+        maxAccel < MIN_ACCEL            ||  maxAccel > MAX_ACCEL  ||
+        targetSteer < MIN_TARGET_STEER  ||  targetSteer > MAX_TARGET_STEER) {
+      log.error("Received operation message with suspect strategy values. targetSpeed = " + targetSpeed +
+                ", maxAccel = " + maxAccel + ", targetSteer = " + targetSteer);
+      return;
+    }
+
     targetSteer = 0;//TODO this is a temporary override as TO26 I-95 routes files do not match lane geometry
 
     plugin.getCooperativeMergeInputs().setCommands(targetSpeed, maxAccel, targetSteer);

--- a/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/StandbyState.java
+++ b/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/StandbyState.java
@@ -51,7 +51,7 @@ public class StandbyState implements ICooperativeMergeState {
 
   protected final static double MIN_RADIUS = 100.0; //meters
   protected final static double MAX_RADIUS = 10000.0; //meters
-  protected final static double MIN_MERGE_DIST_FROM_METER = 0.0; //meters
+  protected final static double MIN_MERGE_DIST_FROM_METER = -10.0; //meters; allow buffer around meter point
   protected final static double MAX_MERGE_DIST_FROM_METER = 1000.0; //meters
   protected final static double MIN_MERGE_LENGTH = 5.0; //meters
   protected final static double MAX_MERGE_LENGTH = 800.0; //meters

--- a/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/StandbyState.java
+++ b/carmajava/cooperativemerge/src/main/java/gov/dot/fhwa/saxton/carma/plugins/cooperativemerge/StandbyState.java
@@ -48,7 +48,14 @@ public class StandbyState implements ICooperativeMergeState {
   protected final static int LOOP_SLEEP_TIME = 1000; // ms
 
   protected final static double CM_PER_M = 100.0;
-  
+
+  protected final static double MIN_RADIUS = 100.0; //meters
+  protected final static double MAX_RADIUS = 10000.0; //meters
+  protected final static double MIN_MERGE_DIST_FROM_METER = 0.0; //meters
+  protected final static double MAX_MERGE_DIST_FROM_METER = 1000.0; //meters
+  protected final static double MIN_MERGE_LENGTH = 5.0; //meters
+  protected final static double MAX_MERGE_LENGTH = 800.0; //meters
+
   protected final CooperativeMergePlugin plugin;
   protected final ILogger log;
   protected final PluginServiceLocator pluginServiceLocator;
@@ -98,6 +105,15 @@ public class StandbyState implements ICooperativeMergeState {
       double meterRadius       = Double.parseDouble(params.get(0));
       double mergeDTDFromMeter = Double.parseDouble(params.get(1));
       double mergeLength       = Double.parseDouble(params.get(2));
+
+      //do a sanity check on the values
+      if (meterRadius < MIN_RADIUS                        ||  meterRadius > MAX_RADIUS  ||
+          mergeDTDFromMeter < MIN_MERGE_DIST_FROM_METER   ||  mergeDTDFromMeter > MAX_MERGE_DIST_FROM_METER  ||
+          mergeLength < MIN_MERGE_LENGTH                  ||  mergeLength > MAX_MERGE_LENGTH) {
+        log.error("Received mobility request with suspect strategy values. meterRadius = " + meterRadius +
+                  ", mergeDTDFromMeter = " + mergeDTDFromMeter + ", mergeLength = " + mergeLength);
+        return MobilityRequestResponse.NO_RESPONSE;
+      }
 
       cav_msgs.LocationECEF meterLoc = msg.getLocation();
       // TODO Probably would be good to add a function to route for doing this complicated process which happens alot

--- a/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/CommandingState.java
+++ b/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/CommandingState.java
@@ -32,9 +32,9 @@ import gov.dot.fhwa.saxton.carma.rosutils.SaxtonLogger;
  * Set the target vehicle speed to the platoon speed and activate the lane change indicator when needed
  */
 public class CommandingState extends RSUMeteringStateBase {
-  protected static final double MIN_METER_DIST = 0.0; //meters
+  protected static final double MIN_METER_DIST = -10.0; //meters; allow some buffer around meter location
   protected static final double MAX_METER_DIST = 1000.0; //meters
-  protected static final double MIN_MERGE_DIST = 5.0; //meters
+  protected static final double MIN_MERGE_DIST = -800.0; //meters
   protected static final double MAX_MERGE_DIST = 800.0; //meters
   protected static final double MIN_SPEED = 0.5; // m/s
   protected static final double MAX_SPEED = 35.0; // m/s - just over 75 mph

--- a/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/CommandingState.java
+++ b/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/CommandingState.java
@@ -32,6 +32,15 @@ import gov.dot.fhwa.saxton.carma.rosutils.SaxtonLogger;
  * Set the target vehicle speed to the platoon speed and activate the lane change indicator when needed
  */
 public class CommandingState extends RSUMeteringStateBase {
+  protected static final double MIN_METER_DIST = 0.0; //meters
+  protected static final double MAX_METER_DIST = 1000.0; //meters
+  protected static final double MIN_MERGE_DIST = 5.0; //meters
+  protected static final double MAX_MERGE_DIST = 800.0; //meters
+  protected static final double MIN_SPEED = 0.5; // m/s
+  protected static final double MAX_SPEED = 35.0; // m/s - just over 75 mph
+  protected static final int    MIN_LANE = 0;
+  protected static final int    MAX_LANE = 5;
+
   protected final static String EXPECTED_OPERATION_PARAMS = "STATUS|METER_DIST:%.2f,MERGE_DIST:%.2f,SPEED:%.2f,LANE:%d";
   protected final static String STATUS_TYPE_PARAM = "STATUS";
   protected final static List<String> OPERATION_PARAMS = new ArrayList<>(Arrays.asList("METER_DIST", "MERGE_DIST", "SPEED", "LANE"));
@@ -95,6 +104,16 @@ public class CommandingState extends RSUMeteringStateBase {
     int lane = Integer.parseInt(params.get(3));
     // Simply updating the command speed to the platoon speed may be enough to make this work
     // If it is not more complex logic can be added
+
+    //perform sanity check on incoming params
+    if (meterDist < MIN_METER_DIST  ||  meterDist > MAX_METER_DIST  ||
+        mergeDist < MIN_MERGE_DIST  ||  mergeDist > MAX_MERGE_DIST  ||
+        speed < MIN_SPEED           ||  speed > MAX_SPEED  ||
+        lane < MIN_LANE             ||  lane > MAX_LANE) {
+      log.warn("Received operation message with suspect strategy variables. meterDist = " + meterDist +
+                ", mergeDist = " + mergeDist + ", speed = " + speed + ", lane = " + lane);
+      return;
+    }
 
     PlatoonData platoon = worker.getNextPlatoon(vehicleId);
     double newCommandSpeed;

--- a/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/HoldingState.java
+++ b/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/HoldingState.java
@@ -29,6 +29,13 @@ import gov.dot.fhwa.saxton.carma.rosutils.SaxtonLogger;
  * State which holds a vehicle at the ramp metering location until it is time to release it
  */
 public class HoldingState extends RSUMeteringStateBase {
+  protected static final double MIN_METER_DIST = 0.0; //meters
+  protected static final double MAX_METER_DIST = 1000.0; //meters
+  protected static final double MIN_MERGE_DIST = 5.0; //meters
+  protected static final double MAX_MERGE_DIST = 800.0; //meters
+  protected static final double MIN_SPEED = 0.5; // m/s
+  protected static final double MAX_SPEED = 35.0; // m/s - just over 75 mph
+
   protected final static String EXPECTED_OPERATION_PARAMS = "STATUS|METER_DIST:%.2f,MERGE_DIST:%.2f,SPEED:%.2f,LANE:%d";
   protected final static String STATUS_TYPE_PARAM = "STATUS";
   protected final static List<String> OPERATION_PARAMS = new ArrayList<>(Arrays.asList("METER_DIST", "MERGE_DIST", "SPEED", "LANE"));
@@ -91,6 +98,15 @@ public class HoldingState extends RSUMeteringStateBase {
     double meterDist = Double.parseDouble(params.get(0));
     double mergeDist = Double.parseDouble(params.get(1));
     double speed = Double.parseDouble(params.get(2));
+
+    //perform sanity checks on the received values
+    if (meterDist < MIN_METER_DIST  ||  meterDist > MAX_METER_DIST  ||
+        mergeDist < MIN_MERGE_DIST  ||  mergeDist > MAX_MERGE_DIST  ||
+        speed < MIN_SPEED           ||  speed > MAX_SPEED) {
+      log.warn("Received operation message with suspect strategy values. meterDist = " + meterDist +
+                ", mergeDist = " + mergeDist + ", speed = " + speed);
+      return;
+    }
 
     // If we are already at the ramp meter or past it then hold there
     if (meterDist < 1.0) {

--- a/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/HoldingState.java
+++ b/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/HoldingState.java
@@ -29,9 +29,9 @@ import gov.dot.fhwa.saxton.carma.rosutils.SaxtonLogger;
  * State which holds a vehicle at the ramp metering location until it is time to release it
  */
 public class HoldingState extends RSUMeteringStateBase {
-  protected static final double MIN_METER_DIST = 0.0; //meters
+  protected static final double MIN_METER_DIST = -10.0; //meters; allow buffer around meter location
   protected static final double MAX_METER_DIST = 1000.0; //meters
-  protected static final double MIN_MERGE_DIST = 5.0; //meters
+  protected static final double MIN_MERGE_DIST = -800.0; //meters
   protected static final double MAX_MERGE_DIST = 800.0; //meters
   protected static final double MIN_SPEED = 0.5; // m/s
   protected static final double MAX_SPEED = 35.0; // m/s - just over 75 mph

--- a/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/RSUMeterWorker.java
+++ b/carmajava/rsumetering/src/main/java/gov/dot/fhwa/saxton/carma/rsumetering/RSUMeterWorker.java
@@ -61,6 +61,8 @@ public class RSUMeterWorker {
   protected final static long NANO_SEC_PER_MS = 1000000L; // Nano-seconds per milli-second
   protected final static long BSM_ID_TIMEOUT = 3000L; // Timeout of a bsm id in ms
   protected final static long PLATOON_TIMEOUT = 4000L; // Timeout of a platooning info message
+  protected static final double MIN_PLATOON_SPEED = 0.5; // m/s - could be more intelligent about comparing these to host's current speed
+  protected static final double MAX_PLATOON_SPEED = 35.0; // m/s
   protected final IRSUMeterManager manager;
   protected final SaxtonLogger log;
   protected final NodeConfiguration nodeConfiguration = NodeConfiguration.newPrivate();
@@ -267,6 +269,13 @@ public class RSUMeterWorker {
     
     double platoonSpeed = Double.parseDouble(paramsArray.get(2));
     String rearBsmId = paramsArray.get(0);
+
+    //perform sanity check on received params - no way to check BSM ID
+    if (platoonSpeed < MIN_PLATOON_SPEED  ||  platoonSpeed > MAX_PLATOON_SPEED) {
+      log.warn("Received operation message with suspect strategy values. platoonSpeed = " + platoonSpeed);
+      return;
+    }
+
     BSM cachedMsg = bsmMap.get(rearBsmId);
     // If we don't have a BSM for this rear vehicle then no value in tracking platoon
     if (cachedMsg == null) {


### PR DESCRIPTION
Thanks for the contribution, this is awesome.

# PR Details

## Description

The idea is to do some level of input validation on values coming in from mobility message strategy strings before using those values as a way to enhance system security.  The strategy string is initially parsed to pull out key/value pairs that match expected key strings. But the values could be anything that an attacker could inject into the message. A bogus value could have unhappy consequences for the vehicle's actions, so we need to check that they are reasonable.  This is a simple first step - more sophistication could be added in the future to narrow the range of acceptable values pertinent to the current situation.

## Related Issue

#202

## Motivation and Context

Desire is to add a bit more security to the system.

## How Has This Been Tested?

Unable to test at this time, but performed personal code review.  I am having several impediments to running unit tests.  This is a good exercise for a new hire.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

* DO NOT MERGE YET - unit tests pending, but wanted to get an early look *