### PR TITLE
Remove obsolete references to deprecated maneuver messages

### DIFF
--- a/carmajava/route/src/main/java/gov/dot/fhwa/saxton/carma/route/RouteWaypoint.java
+++ b/carmajava/route/src/main/java/gov/dot/fhwa/saxton/carma/route/RouteWaypoint.java
@@ -86,16 +86,6 @@ public class RouteWaypoint {
     // String and Integer are immutable so add basic copy will work
     disabledGuidanceAlgorithms.addAll(wp.disabledGuidanceAlgorithms);
     laneClosures.addAll(wp.laneClosures);
-    // Deep copy needed maneuvers
-    for (cav_msgs.Maneuver maneuver: wp.neededManeuvers) {
-      cav_msgs.Maneuver newManeuver = messageFactory.newFromType(Maneuver._TYPE);
-      newManeuver.setType(maneuver.getType());
-      newManeuver.setLaneChangeManeuver(maneuver.getLaneChangeManeuver());
-      newManeuver.setIntersectionTransitStraightManeuver(maneuver.getIntersectionTransitStraightManeuver());
-      newManeuver.setIntersectionTransitLeftTurnManeuver(maneuver.getIntersectionTransitLeftTurnManeuver());
-      newManeuver.setIntersectionTransitRightTurnManeuver(maneuver.getIntersectionTransitRightTurnManeuver());
-      newManeuver.setStopAndWaitManeuver(maneuver.getStopAndWaitManeuver());
-    }
     // Copy remaining fields
     laneCount = wp.laneCount;
     this.setLocation(wp.getLocation());


### PR DESCRIPTION
# PR Details
Fixes issues #213 by removing old references to a former concept of maneuvers that is now being surfaced due to changes in `cav_msgs/Maneuver.msg`.

## Description

By modifying `cav_msgs/Maneuver.msg` this old (apparently unused and unneeded) code was broken. The removed code referenced a deep copy of a set of required maneuvers which was never used and never even stored inside the object that was doing the copy. As such this code has been removed. It may be worth considering removing this field from `cav_msgs/RouteWaypoint.msg` entirely in the near future, as the concept of required maneuvers given a route waypoint doesn't make a ton of sense under our current design.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #213 

## Motivation and Context

Resolved the compilation issue described in #213 

## How Has This Been Tested?
Resolution of the compilation error was verified by compiling locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
