### PR TITLE
NDT Wrapper node

### DIFF
--- a/ndt_pose_tf_wrapper/CMakeLists.txt
+++ b/ndt_pose_tf_wrapper/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(ndt_pose_tf_wrapper)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  geometry_msgs
+  roscpp
+  std_msgs
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+
+catkin_package(
+  CATKIN_DEPENDS geometry_msgs roscpp std_msgs tf2 tf2_ros tf2_geometry_msgs
+)
+
+###########
+## Build ##
+###########
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable( ${PROJECT_NAME} src/ndt_wrapper_node.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+if(catkin_EXPORTED_TARGETS)
+  add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+endif()
+
+#############
+## Install ##
+#############
+
+install(DIRECTORY include/${PROJECT_NAME}/
+DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+FILES_MATCHING PATTERN "*.hpp"
+PATTERN ".svn" EXCLUDE
+)
+
+## Install C++
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Install Other Resources
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/ndt_pose_tf_wrapper/CMakeLists.txt
+++ b/ndt_pose_tf_wrapper/CMakeLists.txt
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2018-2019 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
 cmake_minimum_required(VERSION 2.8.3)
 project(ndt_pose_tf_wrapper)
 

--- a/ndt_pose_tf_wrapper/launch/ndt_pose_tf_wrapper.launch
+++ b/ndt_pose_tf_wrapper/launch/ndt_pose_tf_wrapper.launch
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+        <node pkg="ndt_pose_tf_wrapper" type="ndt_pose_tf_wrapper" name="ndt_pose_tf_wrapper" output="screen">
+            <remap from="ndt_pose" to="/ndt_pose"/>
+        </node>
+</launch>

--- a/ndt_pose_tf_wrapper/launch/ndt_pose_tf_wrapper.launch
+++ b/ndt_pose_tf_wrapper/launch/ndt_pose_tf_wrapper.launch
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
         <node pkg="ndt_pose_tf_wrapper" type="ndt_pose_tf_wrapper" name="ndt_pose_tf_wrapper" output="screen">
-            <remap from="ndt_pose" to="/ndt_pose"/>
         </node>
 </launch>

--- a/ndt_pose_tf_wrapper/launch/ndt_pose_tf_wrapper.launch
+++ b/ndt_pose_tf_wrapper/launch/ndt_pose_tf_wrapper.launch
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-        <node pkg="ndt_pose_tf_wrapper" type="ndt_pose_tf_wrapper" name="ndt_pose_tf_wrapper" output="screen">
+        <node pkg="ndt_pose_tf_wrapper" type="ndt_pose_tf_wrapper" name="ndt_pose_tf_wrapper">
         </node>
 </launch>

--- a/ndt_pose_tf_wrapper/package.xml
+++ b/ndt_pose_tf_wrapper/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>ndt_pose_tf_wrapper</name>
+  <version>1.0.0</version>
+  <description>The ndt_pose_tf_wrapper package that takes in pose messages from ndt_matching node and publishes as tf2 transformation messages</description>
+  <maintainer email="carma@todo.todo">carma</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="carma@todo.todo">carma</author>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>geometry_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>	
+  <depend>tf2_geometry_msgs</depend>
+</package>

--- a/ndt_pose_tf_wrapper/package.xml
+++ b/ndt_pose_tf_wrapper/package.xml
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2018-2019 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
 <?xml version="1.0"?>
 <package format="2">
   <name>ndt_pose_tf_wrapper</name>

--- a/ndt_pose_tf_wrapper/src/ndt_wrapper_node.cpp
+++ b/ndt_pose_tf_wrapper/src/ndt_wrapper_node.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 #include <ros/ros.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>

--- a/ndt_pose_tf_wrapper/src/ndt_wrapper_node.cpp
+++ b/ndt_pose_tf_wrapper/src/ndt_wrapper_node.cpp
@@ -1,0 +1,31 @@
+#include <ros/ros.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/PoseStamped.h>
+
+void ndtPoseCallback(const geometry_msgs::PoseStampedConstPtr& msg){
+	static tf2_ros::TransformBroadcaster br;
+	geometry_msgs::TransformStamped transformStamped;
+	transformStamped.header.stamp = msg->header.stamp;
+	transformStamped.header.frame_id = "map";
+	transformStamped.child_frame_id = "base_link";
+	transformStamped.transform.translation.x = msg->pose.position.x;
+	transformStamped.transform.translation.y = msg->pose.position.y;
+	transformStamped.transform.translation.z = msg->pose.position.z;
+	transformStamped.transform.rotation.x = msg->pose.orientation.x;
+	transformStamped.transform.rotation.y = msg->pose.orientation.y;
+	transformStamped.transform.rotation.z = msg->pose.orientation.z;
+	transformStamped.transform.rotation.w = msg->pose.orientation.w;
+	br.sendTransform(transformStamped);
+}
+
+int main(int argc, char** argv){
+
+  ros::init(argc, argv, "ndt_tf_wrapper");
+  ros::NodeHandle node;
+  ros::Subscriber sub = node.subscribe("ndt_pose", 5, &ndtPoseCallback);
+  ros::spin();
+  return 0;
+
+};


### PR DESCRIPTION
# PR Details
This PR contains a node to integrate NDT matching node from Autoware.
## Description
This node takes the current pose info from ndt_matching and republishes it as a transform between map frame and baselink for the usage of CARMA plarform.
## Related Issue
N/A
## Motivation and Context
CARMA platform takes in localization information by tf2 transform tree. This node makes sure that ndt_matching node outputs is the compatible to CARMA.
## How Has This Been Tested?
Build and test locally.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
