### PR TITLE
Add pure_pursuit_wrapper node

### DIFF
--- a/pure_pursuit_wrapper/CMakeLists.txt
+++ b/pure_pursuit_wrapper/CMakeLists.txt
@@ -159,6 +159,7 @@ add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catk
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}_node
+  pure_pursuit_wrapper_worker_library
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
 )

--- a/pure_pursuit_wrapper/CMakeLists.txt
+++ b/pure_pursuit_wrapper/CMakeLists.txt
@@ -1,0 +1,209 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(pure_pursuit_wrapper)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+add_definitions(-DBOOST_LOG_DYN_LINK=1)
+set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_CXX_FLAGS "-lboost_system") 
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  cav_msgs
+  roscpp
+  rospy
+  std_msgs
+  geometry_msgs
+  autoware_msgs
+  message_filters
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   cav_msgs#   std_msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+ INCLUDE_DIRS include
+#  LIBRARIES pure_pursuit_wrapper
+ CATKIN_DEPENDS cav_msgs roscpp rospy std_msgs geometry_msgs autoware_msgs
+#  DEPENDS system_lib
+ DEPENDS Boost
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/pure_pursuit_wrapper.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+add_executable(${PROJECT_NAME}_node src/pure_pursuit_wrapper_node.cpp src/pure_pursuit_wrapper.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME}_node
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_pure_pursuit_wrapper.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/pure_pursuit_wrapper/CMakeLists.txt
+++ b/pure_pursuit_wrapper/CMakeLists.txt
@@ -186,13 +186,6 @@ install(DIRECTORY include/${PROJECT_NAME}/
   PATTERN ".svn" EXCLUDE
 )
 
-# Mark cpp header files for installation
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
-)
-
 # Mark other files for installation (e.g. launch and bag files, etc.)
 install(DIRECTORY
   launch

--- a/pure_pursuit_wrapper/CMakeLists.txt
+++ b/pure_pursuit_wrapper/CMakeLists.txt
@@ -80,6 +80,9 @@ find_package(Boost REQUIRED COMPONENTS system)
 #   cav_msgs#   std_msgs
 # )
 
+add_library(pure_pursuit_wrapper_worker_library src/pure_pursuit_wrapper_worker.cpp)
+add_dependencies(pure_pursuit_wrapper_worker_library ${catkin_EXPORTED_TARGETS})
+
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
 ################################################
@@ -209,3 +212,9 @@ install(DIRECTORY
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
+
+catkin_add_gtest(${PROJECT_NAME}_test test/${PROJECT_NAME}_test.cpp)
+
+target_link_libraries( ${PROJECT_NAME}_test pure_pursuit_wrapper_worker_library
+        ${catkin_LIBRARIES}
+        )

--- a/pure_pursuit_wrapper/CMakeLists.txt
+++ b/pure_pursuit_wrapper/CMakeLists.txt
@@ -167,33 +167,35 @@ target_link_libraries(${PROJECT_NAME}_node
 # all install targets should use catkin DESTINATION variables
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
 
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+# Mark executable scripts (Python etc.) for installation
+# in contrast to setup.py, you can choose the destination
+install(TARGETS ${PROJECT_NAME}_node wgs84_utils_library transform_maintainer_library
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
-## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+# Mark executables and/or libraries for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
 
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
+# Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+# Mark other files for installation (e.g. launch and bag files, etc.)
+install(DIRECTORY
+  launch
+  # myfile1
+  # myfile2
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 #############
 ## Testing ##

--- a/pure_pursuit_wrapper/CMakeLists.txt
+++ b/pure_pursuit_wrapper/CMakeLists.txt
@@ -169,7 +169,7 @@ target_link_libraries(${PROJECT_NAME}_node
 
 # Mark executable scripts (Python etc.) for installation
 # in contrast to setup.py, you can choose the destination
-install(TARGETS ${PROJECT_NAME}_node wgs84_utils_library transform_maintainer_library
+install(TARGETS ${PROJECT_NAME}_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper.hpp
+++ b/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper.hpp
@@ -73,9 +73,6 @@ class PurePursuitWrapper {
 
         void TrajectoryPlanPoseHandler(const geometry_msgs::PoseStamped::ConstPtr& pose, const cav_msgs::TrajectoryPlan::ConstPtr& tp);
 
-        // Convert TrajectoryPlanPoint to Waypoint. This is used by TrajectoryPlanHandler.
-        autoware_msgs::Waypoint TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp);
-
     private:
 
         //@brief ROS node handle.

--- a/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper.hpp
+++ b/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper.hpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <mutex>
+
+// ROS
+#include <ros/ros.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+
+// msgs
+#include <cav_msgs/SystemAlert.h>
+#include <cav_msgs/TrajectoryPlan.h>
+
+// autoware
+#include "autoware_msgs/Lane.h"
+#include "autoware_config_msgs/ConfigWaypointFollower.h"
+#include "autoware_msgs/ControlCommandStamped.h"
+
+namespace pure_pursuit_wrapper {
+
+/*!
+ * Main class for the node to handle the ROS interfacing.
+ */
+
+class PurePursuitWrapper {
+    public:
+        /*!
+        * Constructor.
+        * @param nodeHandle the ROS node handle.
+        */
+        PurePursuitWrapper(ros::NodeHandle& nodeHandle);
+
+        /*!
+        * Destructor.
+        */
+        virtual ~PurePursuitWrapper();
+
+        // @brief ROS initialize.
+        void Initialize();
+        
+        // runs publish at a desired frequency
+        int rate;
+
+        // Shutdown flags and mutex
+        std::mutex shutdown_mutex_;
+        bool shutting_down_ = false;
+
+        // message filter subscribers
+        message_filters::Subscriber<geometry_msgs::PoseStamped> pose_sub;
+        message_filters::Subscriber<cav_msgs::TrajectoryPlan> trajectory_plan_sub;
+        
+        // SyncPolicy
+        typedef message_filters::sync_policies::ApproximateTime<geometry_msgs::PoseStamped, cav_msgs::TrajectoryPlan> SyncPolicy;
+
+        void TrajectoryPlanPoseHandler(const geometry_msgs::PoseStamped::ConstPtr& pose, const cav_msgs::TrajectoryPlan::ConstPtr& tp);
+
+    private:
+
+        //@brief ROS node handle.
+        ros::NodeHandle& nh_;
+
+        //@brief ROS subscribers.
+        ros::Subscriber system_alert_sub_;
+
+        // @brief ROS publishers.
+        ros::Publisher way_points_pub_;
+        ros::Publisher system_alert_pub_;
+
+        /*!
+        * Reads and verifies the ROS parameters.
+        * @return true if successful.
+        */
+        bool ReadParameters();
+
+        // @brief ROS subscriber handlers.
+        void SystemAlertHandler(const cav_msgs::SystemAlert::ConstPtr& msg);
+
+        // @brief ROS pusblishers.
+        void PublisherForWayPoints(autoware_msgs::Lane& msg);
+
+        // Convert TrajectoryPlanPoint to Waypoint. This is used by TrajectoryPlanHandler.
+        autoware_msgs::Waypoint TrajectoryPlanPointToWaypointConverter(geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp);
+          
+        /*
+         * @brief Handles caught exceptions which have reached the top level of this node
+         * 
+         * @param message The exception to handle
+         * 
+         * If an exception reaches the top level of this node it should be passed to this function.
+         * The function will try to log the exception and publish a FATAL message to system_alert before shutting itself down.
+         */
+        void HandleException(const std::exception& e);
+
+        // @brief Shutsdown this node
+        void Shutdown();
+
+};
+
+}  // namespace pure_pursuit_wrapper

--- a/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper.hpp
+++ b/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper.hpp
@@ -33,6 +33,8 @@
 #include "autoware_config_msgs/ConfigWaypointFollower.h"
 #include "autoware_msgs/ControlCommandStamped.h"
 
+#include "pure_pursuit_wrapper_worker.hpp"
+
 namespace pure_pursuit_wrapper {
 
 /*!
@@ -71,6 +73,9 @@ class PurePursuitWrapper {
 
         void TrajectoryPlanPoseHandler(const geometry_msgs::PoseStamped::ConstPtr& pose, const cav_msgs::TrajectoryPlan::ConstPtr& tp);
 
+        // Convert TrajectoryPlanPoint to Waypoint. This is used by TrajectoryPlanHandler.
+        autoware_msgs::Waypoint TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp);
+
     private:
 
         //@brief ROS node handle.
@@ -83,6 +88,8 @@ class PurePursuitWrapper {
         ros::Publisher way_points_pub_;
         ros::Publisher system_alert_pub_;
 
+        PurePursuitWrapperWorker ppww;
+
         /*!
         * Reads and verifies the ROS parameters.
         * @return true if successful.
@@ -94,9 +101,6 @@ class PurePursuitWrapper {
 
         // @brief ROS pusblishers.
         void PublisherForWayPoints(autoware_msgs::Lane& msg);
-
-        // Convert TrajectoryPlanPoint to Waypoint. This is used by TrajectoryPlanHandler.
-        autoware_msgs::Waypoint TrajectoryPlanPointToWaypointConverter(geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp);
           
         /*
          * @brief Handles caught exceptions which have reached the top level of this node

--- a/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper_worker.hpp
+++ b/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper_worker.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "autoware_msgs/Lane.h"
+#include "autoware_config_msgs/ConfigWaypointFollower.h"
+#include "autoware_msgs/ControlCommandStamped.h"
+#include <geometry_msgs/PoseStamped.h>
+#include <cav_msgs/TrajectoryPlan.h>
+
+namespace pure_pursuit_wrapper {
+
+class PurePursuitWrapperWorker {
+    public:
+        // Convert TrajectoryPlanPoint to Waypoint. This is used by TrajectoryPlanHandler.
+        autoware_msgs::Waypoint TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp);
+};
+}

--- a/pure_pursuit_wrapper/launch/TrajectoryPlan.message
+++ b/pure_pursuit_wrapper/launch/TrajectoryPlan.message
@@ -1,3 +1,0 @@
-'{ header: auto, pose:
-  position: x: 0.0, y: 0.0, z: 0.0
-  orientation: x: 0.0, y: 0.0, w: 0.0 }'

--- a/pure_pursuit_wrapper/launch/TrajectoryPlan.message
+++ b/pure_pursuit_wrapper/launch/TrajectoryPlan.message
@@ -1,0 +1,3 @@
+'{ header: auto, pose:
+  position: x: 0.0, y: 0.0, z: 0.0
+  orientation: x: 0.0, y: 0.0, w: 0.0 }'

--- a/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
+++ b/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
@@ -9,8 +9,4 @@
     <node pkg="pure_pursuit_wrapper" type="pure_pursuit_wrapper_node" name="pure_pursuit_wrapper_node" output="screen">
         <rosparam command="load" file="$(find pure_pursuit_wrapper)/config/default.yaml" />
     </node>
-
-    <!-- pure_pursuit -->
-  <!-- <node pkg="rostopic" type="rostopic" name="config_waypoint_follower_rostopic" args="pub -l -r 100 /config/waypoint_follower autoware_config_msgs/ConfigWaypointFollower '{ header: auto, param_flag: 1, velocity: 5.0, lookahead_distance: 4.0, lookahead_ratio: 2.0, minimum_lookahead_distance: 6.0, displacement_threshold: 0.0, relative_angle_threshold: 0.0 }' "/>
-  <node pkg="rostopic" type="rostopic" name="current_pose_rostopic" args="pub -l -r 100 /current_pose geometry_msgs/PoseStamped '{header: auto, pose: {position: {x: 0, y: 0, z: 0}, orientation: {x: 0, y: 0, w: 0}}}'"/> -->
 </launch>

--- a/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
+++ b/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Pure Pursuit Node -->
+    <include file="$(find waypoint_follower)/launch/pure_pursuit.launch">
+        <arg name="is_linear_interpolation" value="True"/>
+        <arg name="publishes_for_steering_robot" value="True"/>
+    </include>
+    <!-- Pure Pursuit Wrapper Node -->
+    <node pkg="pure_pursuit_wrapper" type="pure_pursuit_wrapper_node" name="pure_pursuit_wrapper_node" output="screen">
+        <rosparam command="load" file="$(find pure_pursuit_wrapper)/config/default.yaml" />
+    </node>
+
+    <!-- pure_pursuit -->
+  <!-- <node pkg="rostopic" type="rostopic" name="config_waypoint_follower_rostopic" args="pub -l -r 100 /config/waypoint_follower autoware_config_msgs/ConfigWaypointFollower '{ header: auto, param_flag: 1, velocity: 5.0, lookahead_distance: 4.0, lookahead_ratio: 2.0, minimum_lookahead_distance: 6.0, displacement_threshold: 0.0, relative_angle_threshold: 0.0 }' "/>
+  <node pkg="rostopic" type="rostopic" name="current_pose_rostopic" args="pub -l -r 100 /current_pose geometry_msgs/PoseStamped '{header: auto, pose: {position: {x: 0, y: 0, z: 0}, orientation: {x: 0, y: 0, w: 0}}}'"/> -->
+</launch>

--- a/pure_pursuit_wrapper/package.xml
+++ b/pure_pursuit_wrapper/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pure_pursuit_wrapper</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>The pure_pursuit_wrapper package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
@@ -13,41 +13,10 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>Apache 2.0</license>
 
+  <author email="carma@todo.todo">carma</author>
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/pure_pursuit_wrapper</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cav_msgs</build_depend>
   <build_depend>roscpp</build_depend>

--- a/pure_pursuit_wrapper/package.xml
+++ b/pure_pursuit_wrapper/package.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pure_pursuit_wrapper</name>
+  <version>0.0.0</version>
+  <description>The pure_pursuit_wrapper package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="carma@todo.todo">carma</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/pure_pursuit_wrapper</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cav_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>autoware_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_export_depend>cav_msgs</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>autoware_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <exec_depend>cav_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>autoware_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "pure_pursuit_wrapper/pure_pursuit_wrapper.hpp"
+
+namespace pure_pursuit_wrapper {
+
+PurePursuitWrapper::PurePursuitWrapper(ros::NodeHandle &nodeHandle): nh_(nodeHandle)
+{
+  if (!ReadParameters())
+  {
+    ROS_ERROR("Could not read parameters.");
+  }
+
+  Initialize();
+
+  ROS_INFO("Successfully launched node.");
+}
+
+PurePursuitWrapper::~PurePursuitWrapper() {
+}
+
+void PurePursuitWrapper::Initialize() {
+  // SystemAlert Subscriber
+  system_alert_sub_ = nh_.subscribe("system_alert", 10, &PurePursuitWrapper::SystemAlertHandler, this);
+  // SystemAlert Publisher
+  system_alert_pub_ = nh_.advertise<cav_msgs::SystemAlert>("system_alert", 10, true);
+
+  // Pose Subscriber
+  pose_sub.subscribe(nh_, "/current_pose", 1);
+  // Trajectory Plan Subscriber
+  trajectory_plan_sub.subscribe(nh_, "trajectory_plan", 1);
+
+  // WayPoints Publisher
+  way_points_pub_ = nh_.advertise<autoware_msgs::Lane>("/final_waypoints", 10, true);
+}
+
+bool PurePursuitWrapper::ReadParameters() {
+  return true;
+}
+
+void PurePursuitWrapper::TrajectoryPlanPoseHandler(const geometry_msgs::PoseStamped::ConstPtr& pose, const cav_msgs::TrajectoryPlan::ConstPtr& tp){
+  ROS_DEBUG_STREAM("Received TrajectoryPlanCurrentPosecallback message");
+    try {
+      autoware_msgs::Lane lane;
+      lane.header = tp->header;
+      std::vector <autoware_msgs::Waypoint> waypoints;
+
+      for(cav_msgs::TrajectoryPlanPoint tpp : tp->trajectory_points) {
+        autoware_msgs::Waypoint waypoint = TrajectoryPlanPointToWaypointConverter(*pose,tpp);
+        waypoints.push_back(waypoint);
+      }
+
+      lane.waypoints = waypoints;
+      PublisherForWayPoints(lane);
+    }
+    catch(const std::exception& e) {
+      HandleException(e);
+    }
+
+};
+
+autoware_msgs::Waypoint PurePursuitWrapper::TrajectoryPlanPointToWaypointConverter(geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp) {
+  ROS_DEBUG_STREAM("Convertering TrajectoryPlanPointToWaypoint");
+
+  autoware_msgs::Waypoint waypoint;
+
+  waypoint.pose.pose.position.x = tpp.x;
+  waypoint.pose.pose.position.y = tpp.y;
+  double begin = ros::Time::now().toSec();
+  double delta_t = tpp.target_time - (begin * 1000);
+
+  waypoint.twist.twist.linear.x = (pose.pose.position.x - tpp.x) / delta_t;
+  waypoint.twist.twist.linear.y = (pose.pose.position.y - tpp.y) / delta_t;
+
+  ROS_DEBUG_STREAM("Finish Convertering TrajectoryPlanPointToWaypoint");
+
+  return waypoint;
+}
+
+void PurePursuitWrapper::SystemAlertHandler(const cav_msgs::SystemAlert::ConstPtr& msg) {
+    try {
+      ROS_INFO_STREAM("Received SystemAlert message of type: " << msg->type);
+      switch(msg->type) {
+        case cav_msgs::SystemAlert::SHUTDOWN: 
+          Shutdown(); 
+          break;
+      }
+    }
+    catch(const std::exception& e) {
+      HandleException(e);
+    }
+};
+
+void PurePursuitWrapper::PublisherForWayPoints(autoware_msgs::Lane& msg){
+  try {
+    ROS_DEBUG_STREAM("Sending WayPoints message.");
+    way_points_pub_.publish(msg);
+  }
+  catch(const std::exception& e) {
+    HandleException(e);
+  }
+};
+
+void PurePursuitWrapper::HandleException(const std::exception& e) {
+  ROS_DEBUG("Sending SystemAlert Message");
+  cav_msgs::SystemAlert alert_msg;
+  alert_msg.type = cav_msgs::SystemAlert::FATAL;
+  alert_msg.description = "Uncaught Exception in " + ros::this_node::getName() + " exception: " + e.what();
+ 
+  ROS_ERROR_STREAM(alert_msg.description);
+  system_alert_pub_.publish(alert_msg);
+
+  ros::Duration(0.05).sleep();
+  Shutdown();
+}
+
+void PurePursuitWrapper::Shutdown() {
+  std::lock_guard<std::mutex> lock(shutdown_mutex_);
+  ROS_WARN_STREAM("Node shutting down");
+  shutting_down_ = true;
+}
+
+}  // namespace pure_pursuit_wrapper

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -58,9 +58,9 @@ void PurePursuitWrapper::TrajectoryPlanPoseHandler(const geometry_msgs::PoseStam
       autoware_msgs::Lane lane;
       lane.header = tp->header;
       std::vector <autoware_msgs::Waypoint> waypoints;
-
+      double current_time = ros::Time::now().toSec();
       for(cav_msgs::TrajectoryPlanPoint tpp : tp->trajectory_points) {
-        autoware_msgs::Waypoint waypoint = TrajectoryPlanPointToWaypointConverter(*pose,tpp);
+        autoware_msgs::Waypoint waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, *pose,tpp);
         waypoints.push_back(waypoint);
       }
 
@@ -73,15 +73,14 @@ void PurePursuitWrapper::TrajectoryPlanPoseHandler(const geometry_msgs::PoseStam
 
 };
 
-autoware_msgs::Waypoint PurePursuitWrapper::TrajectoryPlanPointToWaypointConverter(geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp) {
+autoware_msgs::Waypoint PurePursuitWrapper::TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp) {
   ROS_DEBUG_STREAM("Convertering TrajectoryPlanPointToWaypoint");
 
   autoware_msgs::Waypoint waypoint;
 
   waypoint.pose.pose.position.x = tpp.x;
   waypoint.pose.pose.position.y = tpp.y;
-  double begin = ros::Time::now().toSec();
-  double delta_t = tpp.target_time - (begin * 1000);
+  double delta_t = (tpp.target_time / 1000) - (current_time);
 
   waypoint.twist.twist.linear.x = (pose.pose.position.x - tpp.x) / delta_t;
   waypoint.twist.twist.linear.y = (pose.pose.position.y - tpp.y) / delta_t;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -73,23 +73,6 @@ void PurePursuitWrapper::TrajectoryPlanPoseHandler(const geometry_msgs::PoseStam
 
 };
 
-autoware_msgs::Waypoint PurePursuitWrapper::TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp) {
-  ROS_DEBUG_STREAM("Convertering TrajectoryPlanPointToWaypoint");
-
-  autoware_msgs::Waypoint waypoint;
-
-  waypoint.pose.pose.position.x = tpp.x;
-  waypoint.pose.pose.position.y = tpp.y;
-  double delta_t = (tpp.target_time / 1000) - (current_time);
-
-  waypoint.twist.twist.linear.x = (pose.pose.position.x - tpp.x) / delta_t;
-  waypoint.twist.twist.linear.y = (pose.pose.position.y - tpp.y) / delta_t;
-
-  ROS_DEBUG_STREAM("Finish Convertering TrajectoryPlanPointToWaypoint");
-
-  return waypoint;
-}
-
 void PurePursuitWrapper::SystemAlertHandler(const cav_msgs::SystemAlert::ConstPtr& msg) {
     try {
       ROS_INFO_STREAM("Received SystemAlert message of type: " << msg->type);

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <ros/ros.h>
+#include "pure_pursuit_wrapper/pure_pursuit_wrapper.hpp"
+#include <ros/console.h>
+
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+
+int main(int argc, char** argv) {
+  // if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Info)) { 
+  //   ros::console::notifyLoggerLevelsChanged();
+  // }
+
+  ros::init(argc, argv, "pure_pursuit_wrapper_node");
+  ros::NodeHandle nh("~");
+
+  pure_pursuit_wrapper::PurePursuitWrapper PurePursuitWrapper(nh);
+
+  message_filters::Synchronizer<pure_pursuit_wrapper::PurePursuitWrapper::SyncPolicy> sync(pure_pursuit_wrapper::PurePursuitWrapper::SyncPolicy(10), PurePursuitWrapper.pose_sub, PurePursuitWrapper.trajectory_plan_sub);
+  sync.registerCallback(boost::bind(&pure_pursuit_wrapper::PurePursuitWrapper::TrajectoryPlanPoseHandler, &PurePursuitWrapper, _1, _2));
+
+  while (ros::ok() && !PurePursuitWrapper.shutting_down_) {
+    ros::spinOnce();
+  }
+
+  ROS_INFO("Successfully launched node.");
+  return 0;
+}

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
@@ -23,9 +23,6 @@
 #include <message_filters/sync_policies/approximate_time.h>
 
 int main(int argc, char** argv) {
-  // if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Info)) { 
-  //   ros::console::notifyLoggerLevelsChanged();
-  // }
 
   ros::init(argc, argv, "pure_pursuit_wrapper_node");
   ros::NodeHandle nh("~");

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
@@ -13,9 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+#include "pure_pursuit_wrapper/pure_pursuit_wrapper.hpp"
 
 #include <ros/ros.h>
-#include "pure_pursuit_wrapper/pure_pursuit_wrapper.hpp"
 #include <ros/console.h>
 
 #include <message_filters/subscriber.h>

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char** argv) {
 
   ros::init(argc, argv, "pure_pursuit_wrapper_node");
-  ros::NodeHandle nh("~");
+  ros::NodeHandle nh("");
 
   pure_pursuit_wrapper::PurePursuitWrapper PurePursuitWrapper(nh);
 

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -24,10 +24,16 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
 
   waypoint.pose.pose.position.x = tpp.x;
   waypoint.pose.pose.position.y = tpp.y;
-  double delta_t = (tpp.target_time / 1000) - (current_time);
+  double delta_t_secound = (tpp.target_time / 1000) - current_time;
 
-  waypoint.twist.twist.linear.x = (pose.pose.position.x - tpp.x) / delta_t;
-  waypoint.twist.twist.linear.y = (pose.pose.position.y - tpp.y) / delta_t;
+  if(delta_t_secound != 0) {
+    waypoint.twist.twist.linear.x = 3.6 * (tpp.x - pose.pose.position.x) / delta_t_secound;
+    waypoint.twist.twist.linear.y = 3.6 * (tpp.y - pose.pose.position.y) / delta_t_secound;
+  }
+  else {
+    waypoint.twist.twist.linear.x = 0;
+    waypoint.twist.twist.linear.y = 0;
+  }
 
   return waypoint;
 };

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "pure_pursuit_wrapper/pure_pursuit_wrapper_worker.hpp"
+
+namespace pure_pursuit_wrapper {
+
+autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp) {
+
+  autoware_msgs::Waypoint waypoint;
+
+  waypoint.pose.pose.position.x = tpp.x;
+  waypoint.pose.pose.position.y = tpp.y;
+  double delta_t = (tpp.target_time / 1000) - (current_time);
+
+  waypoint.twist.twist.linear.x = (pose.pose.position.x - tpp.x) / delta_t;
+  waypoint.twist.twist.linear.y = (pose.pose.position.y - tpp.y) / delta_t;
+
+  return waypoint;
+};
+
+}

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -24,7 +24,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
 
   waypoint.pose.pose.position.x = tpp.x;
   waypoint.pose.pose.position.y = tpp.y;
-  double delta_t_secound = (tpp.target_time / 1000) - current_time;
+  double delta_t_secound = (tpp.target_time / 1000.0) - current_time;
 
   if(delta_t_secound != 0) {
     waypoint.twist.twist.linear.x = 3.6 * (tpp.x - pose.pose.position.x) / delta_t_secound;

--- a/pure_pursuit_wrapper/test/pure_pursuit_wrapper_test.cpp
+++ b/pure_pursuit_wrapper/test/pure_pursuit_wrapper_test.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "pure_pursuit_wrapper/pure_pursuit_wrapper_worker.hpp"
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+
+TEST(TrajectoryPlanPointToWaypointConverterTest, test1)
+{  
+
+    geometry_msgs::PoseStamped pose;
+    cav_msgs::TrajectoryPlanPoint tpp;
+
+    double current_time = 0;
+
+    pose.pose.position.x = 0.0;
+    pose.pose.position.y = 0.0;
+    pose.pose.position.z = 0.0;
+
+    tpp.x = 10;
+    tpp.y = 10;
+    tpp.target_time = 10000;
+
+    pure_pursuit_wrapper::PurePursuitWrapperWorker ppww;
+
+    autoware_msgs::Waypoint waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, pose, tpp);
+
+    double v_x = waypoint.twist.twist.linear.x;
+    double correct_v_x = -1;
+
+    EXPECT_EQ(v_x, correct_v_x);
+}
+
+int main(int argc, char**argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/pure_pursuit_wrapper/test/pure_pursuit_wrapper_test.cpp
+++ b/pure_pursuit_wrapper/test/pure_pursuit_wrapper_test.cpp
@@ -23,27 +23,57 @@
 TEST(TrajectoryPlanPointToWaypointConverterTest, test1)
 {  
 
-    geometry_msgs::PoseStamped pose;
+    geometry_msgs::PoseStamped current_pose;
     cav_msgs::TrajectoryPlanPoint tpp;
-
-    double current_time = 0;
-
-    pose.pose.position.x = 0.0;
-    pose.pose.position.y = 0.0;
-    pose.pose.position.z = 0.0;
+    pure_pursuit_wrapper::PurePursuitWrapperWorker ppww;
+    autoware_msgs::Waypoint waypoint;
+    double current_time;
+    
+    current_time = 0;
+    current_pose.pose.position.x = 0.0;
+    current_pose.pose.position.y = 0.0;
 
     tpp.x = 10;
     tpp.y = 10;
     tpp.target_time = 10000;
 
-    pure_pursuit_wrapper::PurePursuitWrapperWorker ppww;
-
-    autoware_msgs::Waypoint waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, pose, tpp);
+    waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, current_pose, tpp);
 
     double v_x = waypoint.twist.twist.linear.x;
-    double correct_v_x = -1;
+    double correct_v_x = 3.6;
 
-    EXPECT_EQ(v_x, correct_v_x);
+    EXPECT_EQ(correct_v_x, v_x);
+
+    current_time = 0;
+    current_pose.pose.position.x = 0.0;
+    current_pose.pose.position.y = 0.0;
+
+    tpp.x = 0;
+    tpp.y = 0;
+    tpp.target_time = 0;
+
+    waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, current_pose, tpp);
+
+    v_x = waypoint.twist.twist.linear.x;
+    correct_v_x = 0;
+
+    EXPECT_EQ(correct_v_x, v_x);
+
+    current_time = 0;
+    current_pose.pose.position.x = 10.0;
+    current_pose.pose.position.y = 10.0;
+
+    tpp.x = 0;
+    tpp.y = 0;
+    tpp.target_time = 10000;
+
+    waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, current_pose, tpp);
+
+    v_x = waypoint.twist.twist.linear.x;
+    correct_v_x = -3.6;
+
+    EXPECT_EQ(correct_v_x, v_x);
+
 }
 
 int main(int argc, char**argv)


### PR DESCRIPTION
Thanks for the contribution, this is awesome.

# PR Details
Add pure_pursuit_wrapper node.

## Description

<!--- Describe your changes in detail -->
The legacy Autoware pure_pursuit node will become a Carma control plugin.  Therefore, it needs to either be modified directly (in the Autoware fork) or a wrapper node needs to be built to interface between it and Carma Guidance so that it looks like a standard control plugin.  In either case, the existing interfaces between pure_pursuit and other Autoware plugins need to be severed.

## Motivation and Context
This feature enables Carma Guidance to communicate with Autoware  pure_pursuit node

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [`x`] My change requires a change to the documentation.
- [`x` ] I have updated the documentation accordingly.
- [`x`] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [`x`] I have added tests to cover my changes.
- [`x`] All new and existing tests passed.
