### PR TITLE
Add map tools for splitting up pcd files

### DIFF
--- a/carma_build
+++ b/carma_build
@@ -39,7 +39,7 @@ rebuild_carma=false
 carma_build_args=""
 autoware_build_args=""
 # The list of packages which are required by carma from autoware
-AUTOWARE_PACKAGE_SELECTION="lidar_localizer map_file deadreckoner points_downsampler lane_planner waypoint_maker autoware_msgs"
+AUTOWARE_PACKAGE_SELECTION="map_tools lidar_localizer map_file deadreckoner points_downsampler lane_planner waypoint_maker autoware_msgs"
 
 # The list of message packages used by autoware which will need to have thier rosjava artifacts generated for carma
 # Note: The order of this list is the order of compilation and therefore must account for dependancies


### PR DESCRIPTION
To split up PCD files larger than 1 GB we need the map tools package from autoware. This PR adds that package to the build.  
