### PR TITLE
Add CARMANodeHandle to provide exception handling

### DIFF
--- a/carma_utils/CMakeLists.txt
+++ b/carma_utils/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(carma_utils)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+  std_srvs
+  cav_msgs
+  cav_srvs
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED)
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS roscpp
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+ include
+ ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+add_library(${PROJECT_NAME}
+  src/${PROJECT_NAME}/CARMAUtils.cpp
+)
+add_dependencies( ${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  # Add gtest based cpp test target and link libraries
+  add_rostest_gtest(${PROJECT_NAME}_CARMANodeHandle_test test/${PROJECT_NAME}/CARMANodeHandle.test
+    test/${PROJECT_NAME}/CARMANodeHandleTest.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}_CARMANodeHandle_test ${PROJECT_NAME} ${catkin_LIBRARIES})
+  add_dependencies( ${PROJECT_NAME}_CARMANodeHandle_test ${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+endif()
+

--- a/carma_utils/include/carma_utils/CARMANodeHandle.h
+++ b/carma_utils/include/carma_utils/CARMANodeHandle.h
@@ -1,0 +1,371 @@
+#pragma once
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <string>
+#include <vector>
+#include <exception>
+#include <ros/ros.h>
+#include <mutex>
+#include <memory>
+#include <cav_msgs/SystemAlert.h>
+
+namespace ros {
+  /**
+   * @class CARMANodeHandle
+   * @brief Extends ros::NodeHandle to provide default exception handling and shutdown behavior
+   * 
+   * Every function which uses callbacks (subscribers, publishers, services, timers) is wrapped in a try catch block
+   * In the event an exception makes it to this class it will result in a SystemAlert message being published and the node shutting down.
+   * 
+   * The exception handling and system alert publication is handled statically and is shared between instances. 
+   * Therefore the user should create a single default CARMANodeHandle() to ensure the system_alert publisher is properly namespaced.
+   * 
+   * The user can add their own exception, alert, and shutdown handling using the set callback functions.
+   * 
+   * This class also provides a spin() function which should be used in place of custom while loops as it will provide exception handling and shutdown behavior. 
+   * A spin callback can be set to perform custom operations during spin.
+   * This class is thread safe
+   */
+
+  class CARMANodeHandle: public NodeHandle
+  {
+
+    private:
+      // Callback typedefs
+      using SystemAlertCB = std::function<void(const cav_msgs::SystemAlertConstPtr&)>;
+      using ShutdownCB = std::function<void()>;
+      using ExceptionCB = std::function<void(const std::exception&)>;
+      using SpinCB = std::function<bool()>;
+      // Callback setting mutex
+      static std::mutex shutdown_mutex_;
+      static std::mutex system_alert_mutex_;
+      static std::mutex exception_mutex_;
+      static std::mutex spin_mutex_;
+      static std::mutex static_pub_sub_mutex_;
+      static bool shutting_down_; // Shutdown flag
+      static std::string system_alert_topic_;
+      static double default_spin_rate_; // Rate in seconds of spin loop
+
+      // System alert pub/sub
+      static volatile bool common_pub_sub_set_;
+      static Subscriber system_alert_sub_;
+      static Publisher system_alert_pub_;
+
+      // Callbacks
+      static SystemAlertCB system_alert_cb_;
+      static ShutdownCB shutdown_cb_;
+      static ExceptionCB exception_cb_;
+      static SpinCB spin_cb_;
+
+      static bool allow_node_shutdown_; // Flag controlling if handle can call ros::shutdown
+
+      /**
+       * @brief Wrapper for pub/sub callbacks which provides exception handling
+       * @param callback A callable which will be used as the callback to wrap
+       * @tparam C The argument type for the callback
+       * 
+       * @return A boost function which wraps callback in exception handling logic
+       */ 
+      template<class C> 
+      boost::function< void(C)> callbackWrapper(const boost::function<void(C)>& callback);
+      /**
+       * @brief Wrapper for service callbacks which provides exception handling
+       * @param callback A callable which will be used as the callback to wrap
+       * @tparam C The argument type for the callback
+       * 
+       * @return A boost function which wraps callback in exception handling logic
+       */ 
+      template<class C, class R>
+      boost::function< bool(C, R)> serviceCallbackWrapper(const boost::function<bool(C, R)>& callback);
+      /**
+       * @brief Wrapper for service callbacks that use the ServiceEvent<> interface which provides exception handling
+       * @param callback A callable which will be used as the callback to wrap
+       * @tparam C The argument type for the callback
+       * 
+       * @return A boost function which wraps callback in exception handling logic
+       */ 
+      template<class E>
+      boost::function< bool(E)> serviceEventCallbackWrapper(const boost::function<bool(E)>& callback);
+
+      /**
+       * @brief Handles incoming SystemAlert messages
+       * 
+       * @param message The message to handle
+       * 
+       * Handles incoming SystemAlert messages and will shutdown this node if that message was of type SHUTDOWN
+       */
+      static void systemAlertHandler(const cav_msgs::SystemAlertConstPtr& message);
+      /**
+       * @brief Handles caught exceptions which have reached the top level of this node
+       * 
+       * @param message The exception to handle
+       * 
+       * If an exception reaches the top level of this node it should be passed to this function.
+       * The function will try to log the exception and publish a FATAL message to system_alert before shutting itself down.
+       */
+      static void handleException(const std::exception& e);
+
+      /**
+      * @brief Shutsdown this node
+      */
+      static void shutdown();
+
+      /**
+       * Helper function checks if the topic name is one already reserved for use by this class
+       */ 
+      static bool isRestrictedTopic(const std::string& topic);
+      /**
+       * Helper function checks the input topic for subscribers
+       */ 
+      static void checkSubscriptionInput(const std::string& topic);
+      /**
+       * Helper function checks the input topic for publishers
+       */ 
+      static void checkPublisherInput(const std::string& topic);
+      /**
+       * Helper function checks the input topic for services
+       */ 
+      static void checkServiceInput(const std::string& service);
+      /**
+       * Helper function validates if a callback can be called
+       */ 
+      template<class C>
+      static void validateCallback(const C& cb);
+      /**
+       * Helper function validates if a function pointer can be called. Intend for use with boost::function objs
+       */ 
+      template<class C>
+      static bool validFunctionPtr(const C& cb);
+
+      /**
+       * Initializes the system alert publisher and subscriber
+       */ 
+      void initPubSub();
+
+    public:
+
+      /**
+       * @brief Set the system alert callback
+       * 
+       * Set a callback to be triggered on receipt of a SystemAlert message.
+       * This callback will be triggered before default alert handling.
+       * The default behavior is to shut this node down if a SHUTDOWN message is received
+       * 
+       * @param cb Callback function
+       */ 
+      static void setSystemAlertCallback(SystemAlertCB cb);
+      /**
+       * @brief Set the shutdown callback
+       * 
+       * Set a callback to be triggered when shutdown is called
+       * This callback will be triggered before the node attempts to shutdown
+       */ 
+      static void setShutdownCallback(ShutdownCB cb);
+      /**
+       * @brief Set the exception callback
+       * 
+       * Set a callback to be triggered when an exception makes it to this node without being caught
+       * A system alert message of type FATAL will be sent before this callback is triggered
+       * After the callback is triggered the node will attempt to shut itself down
+       * 
+       * @param cb Callback function
+       */ 
+      static void setExceptionCallback(ExceptionCB cb);
+      /**
+       * @brief Set the spin callback
+       * 
+       * Set a callback to be triggered during each loop of spin()
+       * This callback will be triggered after each call to spinOnce()
+       * If the callback function returns false the node will attempt to shutdown 
+       * 
+       * @param cb Callback function
+       */ 
+      static void setSpinCallback(SpinCB cb);
+      /**
+       * @brief Exception safe replacement for ros::spin(). 
+       * 
+       * Loops continuously at the rate set by setSpinRate();
+       * On each loop ros::spinOnce() is called then the spinCallback is triggered
+       * This loop will exit and attempt to shutdown the node if the spin callback returns false
+       * 
+       */ 
+      static void spin();
+      /**
+       * @brief Flag determining if the ros::shutdown can be called from CARMANodeHandle functions. NOTE: Not intended for production.
+       * 
+       * This function is not intended for production use and will log a warning if it is called. It is safe to use in testing.
+       * 
+       * @param allow_shutdown Set to false to prevent CARMANodeHandle functions from being able to call ros::shutdown
+       * 
+       */ 
+      static void allowNodeShutdown(const bool allow_shutdown);
+      /**
+       * @brief Sets the spin rate of the spin() function
+       * 
+       * @param hz The rate in Hz at which the spin() function will call ros::spinOnce();
+       * 
+       */ 
+      static void setSpinRate(double hz);
+      /**
+       * @brief Resets the shutdown status of CARMANodeHandle. NOTE: Not intended for production.
+       * 
+       * This function is not intended for production use and will log a warning if it is called. It is safe to use in testing.
+       * 
+       */ 
+      static void resetShutdownStatus();
+      /**
+       * @brief Publish a SystemAlert message
+       * 
+       * @param msg The message to publish
+       */ 
+      void publishSystemAlert(const cav_msgs::SystemAlert& msg);
+      //////
+      // OVERRIDES
+      //   The following methods are overrides of NodeHandle
+      //////
+      CARMANodeHandle	(	const std::string & 	ns = std::string(),
+        const M_string & 	remappings = M_string() 
+      );	
+
+      CARMANodeHandle	(	const CARMANodeHandle & 	rhs	);
+
+      CARMANodeHandle	(	const CARMANodeHandle & 	parent,
+        const std::string & 	ns 
+      );
+      
+      CARMANodeHandle	(	const CARMANodeHandle & 	parent,
+        const std::string & 	ns,
+        const M_string & 	remappings 
+      );
+
+      ~CARMANodeHandle() {};
+
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(M), T *obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(M) const, T *obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &), T *obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &) const, T *obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(M), const boost::shared_ptr< T > &obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(M) const, const boost::shared_ptr< T > &obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &), const boost::shared_ptr< T > &obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class T >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &) const, const boost::shared_ptr< T > &obj, const TransportHints &transport_hints=TransportHints());
+      
+      template<class M >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(*fp)(M), const TransportHints &transport_hints=TransportHints());
+      
+      template<class M >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, void(*fp)(const boost::shared_ptr< M const > &), const TransportHints &transport_hints=TransportHints());
+      
+      template<class M >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, const boost::function< void(const boost::shared_ptr< M const > &)> &callback, const VoidConstPtr &tracked_object=VoidConstPtr(), const TransportHints &transport_hints=TransportHints());
+      
+      template<class M , class C >
+      Subscriber 	subscribe (const std::string &topic, uint32_t queue_size, const boost::function< void(C)> &callback, const VoidConstPtr &tracked_object=VoidConstPtr(), const TransportHints &transport_hints=TransportHints());
+      
+      // NOTE: This function does not support CARMANodeHandle exception handling as there is no way to extract the callback from SubscribeOptions
+      Subscriber subscribe (SubscribeOptions &ops); 
+
+      template<class M >
+      Publisher advertise (const std::string &topic, uint32_t queue_size, bool latch=false);
+      
+      template<class M >
+      Publisher advertise (const std::string &topic, uint32_t queue_size, const SubscriberStatusCallback &connect_cb, const SubscriberStatusCallback &disconnect_cb=SubscriberStatusCallback(), const VoidConstPtr &tracked_object=VoidConstPtr(), bool latch=false);
+
+      Publisher advertise (AdvertiseOptions &ops);
+
+      template<class T , class MReq , class MRes >
+      ServiceServer 	advertiseService (const std::string &service, bool(T::*srv_func)(MReq &, MRes &), T *obj);
+      
+      template<class T , class MReq , class MRes >
+      ServiceServer 	advertiseService (const std::string &service, bool(T::*srv_func)(ServiceEvent< MReq, MRes > &), T *obj);
+      
+      template<class T , class MReq , class MRes >
+      ServiceServer 	advertiseService (const std::string &service, bool(T::*srv_func)(MReq &, MRes &), const boost::shared_ptr< T > &obj);
+      
+      template<class T , class MReq , class MRes >
+      ServiceServer 	advertiseService (const std::string &service, bool(T::*srv_func)(ServiceEvent< MReq, MRes > &), const boost::shared_ptr< T > &obj);
+      
+      template<class MReq , class MRes >
+      ServiceServer 	advertiseService (const std::string &service, bool(*srv_func)(MReq &, MRes &));
+      
+      template<class MReq , class MRes >
+      ServiceServer 	advertiseService (const std::string &service, bool(*srv_func)(ServiceEvent< MReq, MRes > &));
+      
+      template<class MReq , class MRes >
+      ServiceServer 	advertiseService (const std::string &service, const boost::function< bool(MReq &, MRes &)> &callback, const VoidConstPtr &tracked_object=VoidConstPtr());
+      
+      template<class S >
+      ServiceServer 	advertiseService (const std::string &service, const boost::function< bool(S &)> &callback, const VoidConstPtr &tracked_object=VoidConstPtr());
+      
+      // NOTE: This function does not support CARMANodeHandle exception handling as there is no way to extract the callback from AdvertiseServiceOptions
+      ServiceServer 	advertiseService (AdvertiseServiceOptions &ops);
+
+      template<class T >
+      SteadyTimer 	createSteadyTimer (WallDuration period, void(T::*callback)(const SteadyTimerEvent &), T *obj, bool oneshot=false, bool autostart=true);
+      
+      template<class T >
+      SteadyTimer 	createSteadyTimer (WallDuration period, void(T::*callback)(const SteadyTimerEvent &), const boost::shared_ptr< T > &obj, bool oneshot=false, bool autostart=true);
+      
+      SteadyTimer 	createSteadyTimer (WallDuration period, const SteadyTimerCallback &callback, bool oneshot=false, bool autostart=true);
+      
+      SteadyTimer 	createSteadyTimer (SteadyTimerOptions &ops);
+
+      template<class Handler , class Obj >
+      Timer 	createTimer (Rate r, Handler h, Obj o, bool oneshot=false, bool autostart=true);
+
+      template<class T >
+      Timer 	createTimer (Duration period, void(T::*callback)(const TimerEvent &) const, T *obj, bool oneshot=false, bool autostart=true);
+
+      template<class T >
+      Timer 	createTimer (Duration period, void(T::*callback)(const TimerEvent &), T *obj, bool oneshot=false, bool autostart=true);
+
+      template<class T >
+      Timer 	createTimer (Duration period, void(T::*callback)(const TimerEvent &), const boost::shared_ptr< T > &obj, bool oneshot=false, bool autostart=true);
+
+      Timer 	createTimer (Duration period, const TimerCallback &callback, bool oneshot=false, bool autostart=true);
+
+      Timer 	createTimer (TimerOptions &ops);
+
+      template<class T >
+      WallTimer 	createWallTimer (WallDuration period, void(T::*callback)(const WallTimerEvent &), T *obj, bool oneshot=false, bool autostart=true);
+
+      template<class T >
+      WallTimer 	createWallTimer (WallDuration period, void(T::*callback)(const WallTimerEvent &), const boost::shared_ptr< T > &obj, bool oneshot=false, bool autostart=true);
+
+      WallTimer 	createWallTimer (WallDuration period, const WallTimerCallback &callback, bool oneshot=false, bool autostart=true);
+
+      WallTimer 	createWallTimer (WallTimerOptions &ops);
+  };
+}
+
+// Template functions cannot be linked unless the implementation is provided
+// Therefore include implementation to allow for template functions
+#include "../../src/carma_utils/CARMANodeHandle.cpp"

--- a/carma_utils/include/carma_utils/CARMAUtils.h
+++ b/carma_utils/include/carma_utils/CARMAUtils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Convienance file for including carma_utils headers.
+ */ 
+
+#include "CARMANodeHandle.h"

--- a/carma_utils/package.xml
+++ b/carma_utils/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package>
+  <name>carma_utils</name>
+  <version>1.0.0</version>
+  <description>
+    The carma_utils package provides helpful classes for use with the CARMA Platform.
+  </description>
+  <maintainer email="carma@todo.todo">carma</maintainer>
+  <license>Apache 2.0</license>
+  <author email="carma@todo.todo">carma</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>cav_msgs</build_depend>
+  <build_depend>cav_srvs</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>cav_msgs</run_depend>
+  <run_depend>cav_srvs</run_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/carma_utils/src/carma_utils/CARMANodeHandle.cpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.cpp
@@ -1,0 +1,642 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License") { you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * CPP File containing CARMANodeHandle method definitions
+ */
+
+#include <sstream>
+#include "carma_utils/CARMANodeHandle.h"
+
+
+namespace ros {
+  // Initialize default static values
+
+   std::mutex CARMANodeHandle::shutdown_mutex_;
+   std::mutex CARMANodeHandle::system_alert_mutex_;
+   std::mutex CARMANodeHandle::exception_mutex_;
+   std::mutex CARMANodeHandle::spin_mutex_;
+   bool CARMANodeHandle::shutting_down_ = false;
+   bool CARMANodeHandle::allow_node_shutdown_ = true;
+   std::string CARMANodeHandle::system_alert_topic_ = "system_alert";
+   double CARMANodeHandle::default_spin_rate_ = 20.0;
+
+   std::mutex CARMANodeHandle::static_pub_sub_mutex_;
+   volatile bool CARMANodeHandle::common_pub_sub_set_ = false;
+   Subscriber CARMANodeHandle::system_alert_sub_;
+   Publisher CARMANodeHandle::system_alert_pub_;
+
+   CARMANodeHandle::SystemAlertCB CARMANodeHandle::system_alert_cb_;
+
+   CARMANodeHandle::ShutdownCB CARMANodeHandle::shutdown_cb_;
+
+   CARMANodeHandle::ExceptionCB CARMANodeHandle::exception_cb_;
+
+   CARMANodeHandle::SpinCB CARMANodeHandle::spin_cb_;
+
+  CARMANodeHandle::CARMANodeHandle(	const std::string & ns, const M_string & 	remappings)
+    : NodeHandle(ns, remappings) 
+  {
+    initPubSub();
+  }
+
+  CARMANodeHandle::CARMANodeHandle(	const CARMANodeHandle & rhs	) 
+    : NodeHandle(rhs)
+  {
+    initPubSub();
+  }
+
+  CARMANodeHandle::CARMANodeHandle(	const CARMANodeHandle & parent, const std::string & ns )
+    : NodeHandle(parent, ns)
+  {
+    initPubSub();
+  }
+
+  CARMANodeHandle::CARMANodeHandle	(	const CARMANodeHandle & parent,
+    const std::string & 	ns,
+    const M_string & 	remappings)
+    : NodeHandle(parent, ns, remappings)
+  {
+    initPubSub();
+  }
+
+  void CARMANodeHandle::initPubSub() {
+    std::lock_guard<std::mutex> lock(static_pub_sub_mutex_);
+    if (!common_pub_sub_set_) {
+      system_alert_sub_ = this->subscribe(system_alert_topic_, 5, &CARMANodeHandle::systemAlertHandler);
+      system_alert_pub_ = this->advertise<cav_msgs::SystemAlert>(system_alert_topic_, 5, true);
+      common_pub_sub_set_ = true;
+    }
+  }
+
+  void CARMANodeHandle::systemAlertHandler(const cav_msgs::SystemAlertConstPtr& msg) {
+    ROS_INFO_STREAM("Received SystemAlert message of type: " << msg->type);
+    
+    std::lock_guard<std::mutex> lock(system_alert_mutex_);
+    if (validFunctionPtr(system_alert_cb_)) {
+      system_alert_cb_(msg); // Allow user to react to system alert message
+    }
+
+    // Take action if shutdown message
+    switch(msg->type) {
+      case cav_msgs::SystemAlert::SHUTDOWN: 
+        shutdown(); // Shutdown this node when a SHUTDOWN request is received
+        break;
+    }
+  }
+
+  void CARMANodeHandle::publishSystemAlert(const cav_msgs::SystemAlert& msg) {
+    system_alert_pub_.publish(msg);
+  }
+
+  void CARMANodeHandle::setSpinCallback(SpinCB cb) {
+    std::lock_guard<std::mutex> lock(spin_mutex_);
+    validateCallback(cb);
+    spin_cb_ = cb;
+  }
+
+  void CARMANodeHandle::allowNodeShutdown(const bool allow_shutdown) {
+    std::lock_guard<std::mutex> lock(shutdown_mutex_);
+    if (allow_shutdown == false) {
+      ROS_WARN("CARMANodeHandle::allowNodeShutdown(false) has been called. This is risky in production code, but allowable in testing.");
+    }
+    allow_node_shutdown_ = allow_shutdown;
+  }
+
+  void CARMANodeHandle::resetShutdownStatus() {
+    std::lock_guard<std::mutex> lock(shutdown_mutex_);
+    if (allow_node_shutdown_ == true) {
+      ROS_WARN("CARMANodeHandle::resetShutdownStatus() has been called while allowNodeShutdown(true). This is not allowed and no action is taken.");
+      return;
+    }
+    ROS_WARN("CARMANodeHandle::resetShutdownStatus() has been called. This is risky in production code, but allowable in testing.");
+    shutting_down_ = false;
+  }
+
+  void CARMANodeHandle::setSpinRate(double hz) {
+    std::lock_guard<std::mutex> lock(spin_mutex_);
+    default_spin_rate_ = hz;
+  }
+
+  void CARMANodeHandle::spin() {
+    ROS_INFO("Entered Spin: Waiting for any other calls to spin to complete");
+    std::lock_guard<std::mutex> lock(spin_mutex_);
+    ROS_INFO("Obtained lock. Starting spin");
+    // Continuosly process callbacks for default_nh_ using the GlobalCallbackQueue
+    ros::Rate r(default_spin_rate_);
+    while (ros::ok() && !shutting_down_)
+    {
+      ros::spinOnce();
+      try {
+        if (validFunctionPtr(spin_cb_) && !spin_cb_()) {
+          cav_msgs::SystemAlert alert_msg;
+          alert_msg.type = cav_msgs::SystemAlert::WARNING;
+          alert_msg.description = "Node: " + ros::this_node::getName() + " cleanly shutting down using CARMANodeHandle after spin callback returned false";
+          ROS_WARN_STREAM(alert_msg.description); // Log notice
+
+          system_alert_pub_.publish(alert_msg); // Notify the rest of the system
+          shutdown();
+        }
+      }
+      catch(const std::exception& e) {
+        handleException(e);
+      }
+      r.sleep();
+    }
+    
+    { // Empty scope for applying lock_guard for shutdown
+      std::lock_guard<std::mutex> lock(shutdown_mutex_);
+      // Request ros node shutdown before exit
+      if (allow_node_shutdown_) {
+        ros::shutdown();
+      } else {
+        ROS_WARN("Node shutdown attempted but CARMANodeHandle::allowNodeShutdown(false) has been called");
+      }
+    }
+  }
+
+  void CARMANodeHandle::handleException(const std::exception& e) {
+    std::lock_guard<std::mutex> lock(exception_mutex_);
+    // Create system alert message
+    cav_msgs::SystemAlert alert_msg;
+    alert_msg.type = cav_msgs::SystemAlert::FATAL;
+    alert_msg.description = "Uncaught Exception in " + ros::this_node::getName() + " exception: " + e.what();
+  
+    ROS_ERROR_STREAM(alert_msg.description); // Log exception
+
+    system_alert_pub_.publish(alert_msg); // Notify the rest of the system
+
+    if (validFunctionPtr(exception_cb_)) {
+      exception_cb_(e); // Allow user to react to exception
+    }
+
+    ros::Duration(0.05).sleep(); // Leave a small amount of time for the alert to be published
+    shutdown(); // Shutdown this node
+  }
+
+  void CARMANodeHandle::shutdown() {
+    std::lock_guard<std::mutex> lock(shutdown_mutex_);
+    if (validFunctionPtr(shutdown_cb_)) {
+      shutdown_cb_(); // Allow user to react to shutdown request
+    }
+    
+    ROS_WARN_STREAM("Node shutting down");
+    shutting_down_ = true;
+  }
+
+  bool CARMANodeHandle::isRestrictedTopic(const std::string& topic) {
+    return system_alert_topic_ == topic;
+  }
+
+  void CARMANodeHandle::checkSubscriptionInput(const std::string& topic) {
+    if (isRestrictedTopic(topic) && common_pub_sub_set_) {
+      ROS_WARN_STREAM("User requested subscription to existing CARMANodeHandle reserved topic: " << topic);
+    }
+  }
+
+  void CARMANodeHandle::checkPublisherInput(const std::string& topic) {
+    if (isRestrictedTopic(topic) && common_pub_sub_set_) {
+      ROS_WARN_STREAM("User requested publisher to existing CARMANodeHandle reserved topic: " << topic);
+    }
+  }
+
+  void CARMANodeHandle::checkServiceInput(const std::string& service) {
+    if (isRestrictedTopic(service) && common_pub_sub_set_) {
+      ROS_WARN_STREAM("User requested creation of service server for existing CARMANodeHandle reserved service/topic name: " << service);
+    }
+  }
+
+  template<class C>
+  bool CARMANodeHandle::validFunctionPtr(const C& cb) {
+    return !(!cb);
+  }
+
+  template<class C>
+  void CARMANodeHandle::validateCallback(const C& cb) { 
+    if (!validFunctionPtr(cb)) {
+      std::ostringstream msg;
+      msg << "Invalid callback used in CARMANodeHandle: Callback does not point to callable object";
+      throw std::invalid_argument(msg.str());
+    }
+  }
+
+  void CARMANodeHandle::setSystemAlertCallback(SystemAlertCB cb) {
+    std::lock_guard<std::mutex> lock(system_alert_mutex_);
+    validateCallback(cb);
+    system_alert_cb_ = cb;
+  }
+
+  void CARMANodeHandle::setShutdownCallback(ShutdownCB cb) {
+    std::lock_guard<std::mutex> lock(shutdown_mutex_);
+    validateCallback(cb);
+    shutdown_cb_ = cb;
+  }
+
+  void CARMANodeHandle::setExceptionCallback(ExceptionCB cb) { 
+    std::lock_guard<std::mutex> lock(exception_mutex_);
+    validateCallback(cb);
+    exception_cb_ = cb;
+  }
+
+  template<class C>
+  boost::function< void(C)> CARMANodeHandle::callbackWrapper(const boost::function<void(C)>& callback) {
+    validateCallback(callback);
+
+    boost::function< void(C)> wrappedFunc = 
+    [callback] (const C& msg) -> void {
+      try {
+        callback(msg);
+      } catch(const std::exception& e) {
+        handleException(e);
+      }
+    };
+
+    return wrappedFunc;
+  }
+
+  template<class C, class R>
+  boost::function< bool(C, R)> CARMANodeHandle::serviceCallbackWrapper(const boost::function<bool(C, R)>& callback) {
+    validateCallback(callback);
+
+    boost::function< bool(C, R)> wrappedFunc = 
+    [callback] (C req, R res) -> bool {
+      try {
+        callback(req, res);
+      } catch(const std::exception& e) {
+        handleException(e);
+      }
+    };
+
+    return wrappedFunc;
+  }
+
+  template<class E>
+  boost::function< bool(E)> CARMANodeHandle::serviceEventCallbackWrapper(const boost::function<bool(E)>& callback) {
+    validateCallback(callback);
+
+    boost::function< bool(E)> wrappedFunc = 
+    [callback] (E event) -> bool {
+      try {
+        callback(event);
+      } catch(const std::exception& e) {
+        handleException(e);
+      }
+    };
+
+    return wrappedFunc;
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(M), T *obj, const TransportHints &transport_hints) {
+
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<M>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(M) const, T *obj, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<M>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &), T *obj, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<const boost::shared_ptr< M const > &>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &) const, T *obj, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<const boost::shared_ptr< M const > &>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(M), const boost::shared_ptr< T > &obj, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<M>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(M) const, const boost::shared_ptr< T > &obj, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<M>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &), const boost::shared_ptr< T > &obj, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<const boost::shared_ptr< M const > &>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M , class T >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(T::*fp)(const boost::shared_ptr< M const > &) const, const boost::shared_ptr< T > &obj, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<const boost::shared_ptr< M const > &>(boost::bind(fp, obj, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(*fp)(M), const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<M>(boost::bind(fp, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, void(*fp)(const boost::shared_ptr< M const > &), const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<const boost::shared_ptr< M const > &>(boost::bind(fp, _1));
+    return NodeHandle::subscribe<M>(topic, queue_size, func, VoidConstPtr(), transport_hints);
+  }
+
+  template<class M >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, const boost::function< void(const boost::shared_ptr< M const > &)> &callback, const VoidConstPtr &tracked_object, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<const boost::shared_ptr< M const > &>(callback);
+    return NodeHandle::subscribe<M>(topic, queue_size, func, tracked_object, transport_hints);
+  }
+
+  template<class M , class C >
+  Subscriber CARMANodeHandle::subscribe(const std::string &topic, uint32_t queue_size, const boost::function< void(C)> &callback, const VoidConstPtr &tracked_object, const TransportHints &transport_hints) {
+    
+    checkSubscriptionInput(topic);
+
+    auto func = callbackWrapper<C>(callback);
+    return NodeHandle::subscribe<M>(topic, queue_size, func, tracked_object, transport_hints);
+  }
+
+  Subscriber CARMANodeHandle::subscribe(SubscribeOptions &ops) {
+    ROS_WARN("subscribe(SubscribeOptions) called from CARMANodeHandle. This overload does not support exception handling. The user must implement their own");
+
+    return NodeHandle::subscribe(ops);
+  }
+
+  template<class M >
+  Publisher CARMANodeHandle::advertise (const std::string &topic, uint32_t queue_size, bool latch) {
+    checkPublisherInput(topic);
+    return NodeHandle::advertise<M>(topic, queue_size, latch);
+  }
+  
+  template<class M >
+  Publisher CARMANodeHandle::advertise (const std::string &topic, uint32_t queue_size, const SubscriberStatusCallback &connect_cb, const SubscriberStatusCallback &disconnect_cb, const VoidConstPtr &tracked_object, bool latch) {
+    checkPublisherInput(topic);
+    // Check if callbacks are set and if not set them to empty lambdas to prevent need for empty checks throughout code
+    SubscriberStatusCallback new_connect_cb = connect_cb;
+    SubscriberStatusCallback new_disconnect_cb = disconnect_cb;
+    if (!validFunctionPtr(connect_cb)) {
+      new_connect_cb = [](const SingleSubscriberPublisher& ssp) -> void {};
+    }
+    if (!validFunctionPtr(disconnect_cb)) {
+      new_disconnect_cb = [](const SingleSubscriberPublisher& ssp) -> void {};
+    }
+
+    auto connect_func = callbackWrapper<const SingleSubscriberPublisher&>(new_connect_cb);
+    auto disconnect_func = callbackWrapper<const SingleSubscriberPublisher&>(new_disconnect_cb);
+    return NodeHandle::advertise<M>(topic, queue_size, connect_func, disconnect_func, tracked_object, latch);
+  }
+  
+  Publisher CARMANodeHandle::advertise (AdvertiseOptions &ops) {
+    checkPublisherInput(ops.topic);
+    // Check if callbacks are set and if not set them to empty lambdas to prevent need for empty checks throughout code
+    if (!validFunctionPtr(ops.connect_cb)) {
+      ops.connect_cb = [](const SingleSubscriberPublisher& ssp) -> void {};
+    }
+    if (!validFunctionPtr(ops.disconnect_cb)) {
+      ops.disconnect_cb = [](const SingleSubscriberPublisher& ssp) -> void {};
+    }
+
+    auto connect_func = callbackWrapper<const SingleSubscriberPublisher&>(ops.connect_cb);
+    auto disconnect_func = callbackWrapper<const SingleSubscriberPublisher&>(ops.disconnect_cb);
+
+    AdvertiseOptions carma_ops(ops.topic, ops.queue_size, ops.md5sum,
+      ops.datatype, ops.message_definition, connect_func, disconnect_func
+    );
+
+    return NodeHandle::advertise(carma_ops);
+  }
+
+  template<class T , class MReq , class MRes >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, bool(T::*srv_func)(MReq &, MRes &), T *obj) {
+    checkServiceInput(service);
+
+    auto func = serviceCallbackWrapper<MReq&, MRes&>(boost::bind(srv_func, obj, _1, _2));
+    return NodeHandle::advertiseService(service, func, VoidConstPtr());
+  }
+  
+  template<class T , class MReq , class MRes >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, bool(T::*srv_func)(ServiceEvent< MReq, MRes > &), T *obj) {
+    checkServiceInput(service);
+
+    auto func = serviceEventCallbackWrapper<ServiceEvent< MReq, MRes > &>(boost::bind(srv_func, obj, _1));
+    return NodeHandle::advertiseService(service, func, VoidConstPtr());
+  }
+  
+  template<class T , class MReq , class MRes >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, bool(T::*srv_func)(MReq &, MRes &), const boost::shared_ptr< T > &obj) {
+    checkServiceInput(service);
+
+    auto func = serviceCallbackWrapper<MReq&, MRes&>(boost::bind(srv_func, obj, _1, _2));
+    return NodeHandle::advertiseService(service, func, VoidConstPtr());
+  }
+  
+  template<class T , class MReq , class MRes >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, bool(T::*srv_func)(ServiceEvent< MReq, MRes > &), const boost::shared_ptr< T > &obj) {
+    checkServiceInput(service);
+
+    auto func = serviceEventCallbackWrapper<ServiceEvent< MReq, MRes > &>(boost::bind(srv_func, obj, _1));
+    return NodeHandle::advertiseService(service, func, VoidConstPtr());
+  }
+  
+  template<class MReq , class MRes >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, bool(*srv_func)(MReq &, MRes &)) {
+    checkServiceInput(service);
+
+    auto func = serviceCallbackWrapper<MReq&, MRes&>(boost::bind(srv_func, _1, _2));
+    return NodeHandle::advertiseService(service, func, VoidConstPtr());
+  }
+  
+  template<class MReq , class MRes >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, bool(*srv_func)(ServiceEvent< MReq, MRes > &)) {
+    checkServiceInput(service);
+
+    auto func = serviceEventCallbackWrapper<ServiceEvent< MReq, MRes > &>(boost::bind(srv_func, _1));
+    return NodeHandle::advertiseService(service, func, VoidConstPtr());
+  }
+  
+  template<class MReq , class MRes >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, const boost::function< bool(MReq &, MRes &)> &callback, const VoidConstPtr &tracked_object) {
+    checkServiceInput(service);
+
+    auto func = serviceCallbackWrapper<MReq&, MRes&>(callback);
+    return NodeHandle::advertiseService(service, func, tracked_object);
+  }
+  
+  template<class S >
+  ServiceServer CARMANodeHandle::advertiseService (const std::string &service, const boost::function< bool(S &)> &callback, const VoidConstPtr &tracked_object) {
+    checkServiceInput(service);
+
+    auto func = serviceEventCallbackWrapper<S &>(callback);
+    return NodeHandle::advertiseService(service, func, tracked_object);
+  }
+  
+  ServiceServer CARMANodeHandle::advertiseService (AdvertiseServiceOptions &ops) {
+
+    ROS_WARN("advertiseService(AdvertiseServiceOptions) called from CARMANodeHandle. This overload does not support exception handling. The user must implement their own");
+    return NodeHandle::advertiseService(ops);
+  }
+
+  template<class T >
+  SteadyTimer CARMANodeHandle::createSteadyTimer (WallDuration period, void(T::*callback)(const SteadyTimerEvent &), T *obj, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const SteadyTimerEvent &>(boost::bind(callback, obj, _1));
+    return NodeHandle::createSteadyTimer(period, func, oneshot, autostart);
+  }
+  
+  template<class T >
+  SteadyTimer CARMANodeHandle::createSteadyTimer (WallDuration period, void(T::*callback)(const SteadyTimerEvent &), const boost::shared_ptr< T > &obj, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const SteadyTimerEvent &>(boost::bind(callback, obj, _1));
+    return NodeHandle::createSteadyTimer(period, func, oneshot, autostart);
+  }
+  
+  SteadyTimer CARMANodeHandle::createSteadyTimer (WallDuration period, const SteadyTimerCallback &callback, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const SteadyTimerEvent &>(callback);
+    return NodeHandle::createSteadyTimer(period, func, oneshot, autostart);
+  }
+  
+  SteadyTimer CARMANodeHandle::createSteadyTimer (SteadyTimerOptions &ops) {
+
+    auto func = callbackWrapper<const SteadyTimerEvent &>(ops.callback);
+    SteadyTimerOptions carma_ops(ops.period, func, ops.callback_queue, ops.oneshot, ops.autostart);
+
+    return NodeHandle::createSteadyTimer(carma_ops);
+  }
+
+  template<class Handler , class Obj >
+  Timer CARMANodeHandle::createTimer (Rate r, Handler h, Obj o, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const TimerEvent&>(h);
+
+    return NodeHandle::createTimer (r.expectedCycleTime(), 
+      func,
+      oneshot, autostart);
+  }
+
+  template<class T >
+  Timer CARMANodeHandle::createTimer (Duration period, void(T::*callback)(const TimerEvent &) const, T *obj, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const TimerEvent &>(boost::bind(callback, obj, _1));
+    return NodeHandle::createTimer(period, func, oneshot, autostart);
+  }
+
+  template<class T >
+  Timer CARMANodeHandle::createTimer (Duration period, void(T::*callback)(const TimerEvent &), T *obj, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const TimerEvent &>(boost::bind(callback, obj, _1));
+    return NodeHandle::createTimer(period, func, oneshot, autostart);
+  }
+
+  template<class T >
+  Timer CARMANodeHandle::createTimer (Duration period, void(T::*callback)(const TimerEvent &), const boost::shared_ptr< T > &obj, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const TimerEvent &>(boost::bind(callback, obj, _1));
+    return NodeHandle::createTimer(period, func, oneshot, autostart);
+  }
+
+  Timer CARMANodeHandle::createTimer (Duration period, const TimerCallback &callback, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const TimerEvent &>(boost::bind(callback, _1));
+    return NodeHandle::createTimer(period, func, oneshot, autostart);
+  }
+
+  Timer CARMANodeHandle::createTimer (TimerOptions &ops) {
+
+    auto func = callbackWrapper<const TimerEvent &>(ops.callback);
+
+    TimerOptions carma_ops (ops.period, 
+      func,
+      ops.callback_queue, ops.oneshot, ops.autostart
+    );
+
+    carma_ops.tracked_object = ops.tracked_object;
+
+    return NodeHandle::createTimer(carma_ops);
+  }
+
+  template<class T >
+  WallTimer CARMANodeHandle::createWallTimer (WallDuration period, void(T::*callback)(const WallTimerEvent &), T *obj, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const WallTimerEvent &>(boost::bind(callback, obj, _1));
+    return NodeHandle::createWallTimer(period, func, oneshot, autostart);
+  }
+
+  template<class T >
+  WallTimer CARMANodeHandle::createWallTimer (WallDuration period, void(T::*callback)(const WallTimerEvent &), const boost::shared_ptr< T > &obj, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const WallTimerEvent &>(boost::bind(callback, obj, _1));
+    return NodeHandle::createWallTimer(period, func, oneshot, autostart);
+  }
+
+  WallTimer CARMANodeHandle::createWallTimer (WallDuration period, const WallTimerCallback &callback, bool oneshot, bool autostart) {
+
+    auto func = callbackWrapper<const WallTimerEvent &>(boost::bind(callback, _1));
+    return NodeHandle::createWallTimer(period, func, oneshot, autostart);
+  }
+
+  WallTimer CARMANodeHandle::createWallTimer (WallTimerOptions &ops) {
+
+    auto func = callbackWrapper<const WallTimerEvent &>(ops.callback);
+
+    WallTimerOptions carma_ops (ops.period, 
+      func,
+      ops.callback_queue, ops.oneshot, ops.autostart
+    );
+
+    carma_ops.tracked_object = ops.tracked_object;
+
+    return NodeHandle::createWallTimer(carma_ops);
+  }
+}

--- a/carma_utils/src/carma_utils/CARMAUtils.cpp
+++ b/carma_utils/src/carma_utils/CARMAUtils.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Library implementation entry point file. This file can be used to generate .o files for templated classes which include their implementation in the header. 
+ */ 
+
+#include "carma_utils/CARMAUtils.h"

--- a/carma_utils/test/carma_utils/CARMANodeHandle.test
+++ b/carma_utils/test/carma_utils/CARMANodeHandle.test
@@ -1,0 +1,4 @@
+<!-- rostest file for testing the CARMANodeHandle NodeHandle wrapper -->
+<launch>
+  <test test-name="carma_utils_CARMANodeHandle_test" pkg="carma_utils" type="carma_utils_CARMANodeHandle_test" />
+</launch>

--- a/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
+++ b/carma_utils/test/carma_utils/CARMANodeHandleTest.cpp
@@ -1,0 +1,600 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License") { you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <ros/ros.h>
+#include <ros/package.h>
+#include <ros/callback_queue.h>
+#include <std_msgs/Bool.h>
+#include <std_srvs/SetBool.h>
+#include <cav_msgs/SystemAlert.h>
+#include "carma_utils/CARMANodeHandle.h"
+#include "CallRecorder.h"
+
+using namespace ros;
+
+class A {
+  public:
+
+    std::string unique_obj_name_ = "";
+    std::string unique_test_name_ = "";
+    //// 
+    // Subscription Callbacks
+    ////
+    void cb_1(const std_msgs::Bool& msg) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_1");
+    }
+    void cb_2(const std_msgs::Bool& msg) const {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_2");
+    }
+    void cb_3(const std_msgs::BoolConstPtr& msg) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_3");
+    }
+    void cb_4(const std_msgs::BoolConstPtr& msg) const {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_4");
+    }
+    void cb_5(const std_msgs::Bool& msg) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_5");
+    }
+    void cb_6(const std_msgs::Bool& msg) const {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_6");
+    }
+    void cb_7(const std_msgs::BoolConstPtr& msg) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_7");
+    }
+    void cb_8(const std_msgs::BoolConstPtr& msg) const {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_8");
+    }
+    //// 
+    // Service Callbacks
+    ////
+    bool cb_s1(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_s1");
+      return true;
+    }
+    bool cb_s2(ServiceEvent<std_srvs::SetBool::Request, std_srvs::SetBool::Response>& event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_s2");
+      return true;
+    }
+    bool cb_s3(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_s3");
+      return true;
+    }
+    bool cb_s4(ServiceEvent<std_srvs::SetBool::Request, std_srvs::SetBool::Response>& event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_s4");
+      return true;
+    }
+    //// 
+    // SteadyTimer Callbacks
+    ////
+    void cb_st1(const SteadyTimerEvent & event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_st1");
+    }
+    void cb_st2(const SteadyTimerEvent & event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_st2");
+    }
+    ////
+    // Timer Callbacks
+    ////
+    void cb_t2(const TimerEvent & event) const {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_t2");
+    }
+    void cb_t3(const TimerEvent & event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_t3");
+    }
+    void cb_t4(const TimerEvent & event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_t4");
+    }
+    ////
+    // WallTimer Callbacks
+    ////
+    void cb_wt1(const WallTimerEvent & event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_wt1");
+    }
+    void cb_wt2(const WallTimerEvent & event) {
+      CallRecorder::markCalled(unique_test_name_, "A:" + unique_obj_name_ + ":cb_wt2");
+    }
+};
+////
+// Subscription Free Callbacks
+////
+void cb_9(const std_msgs::Bool& msg) {
+  CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::cb_9");
+}
+void cb_10(const std_msgs::BoolConstPtr& msg) {
+  CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::cb_10");
+}
+void cb_11(const std_msgs::BoolConstPtr& msg) {
+  CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::cb_11");
+}
+void cb_12(const std_msgs::Bool& msg) {
+  CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::cb_12");
+}
+void cb_13(const std_msgs::BoolConstPtr& msg) {
+  CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::cb_13");
+}
+void cb_14(const std_msgs::BoolConstPtr& msg) {
+  CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::cb_14");
+}
+////
+// Service Free Callbacks
+////
+bool cb_s5(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res) {
+  CallRecorder::markCalled("testCARMANodeHandleServices","::cb_s5");
+  return true;
+}
+bool cb_s6(ServiceEvent<std_srvs::SetBool::Request, std_srvs::SetBool::Response>& event) {
+  CallRecorder::markCalled("testCARMANodeHandleServices","::cb_s6");
+  return true;
+}
+bool cb_s7(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res) {
+  CallRecorder::markCalled("testCARMANodeHandleServices","::cb_s7");
+  return true;
+}
+bool cb_s8(ServiceEvent<std_srvs::SetBool::Request, std_srvs::SetBool::Response>& event) {
+  CallRecorder::markCalled("testCARMANodeHandleServices","::cb_s8");
+  return true;
+}
+bool cb_s9(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res) {
+  CallRecorder::markCalled("testCARMANodeHandleServices","::cb_s9");
+  return true;
+}
+////
+// SteadyTimer Free Callbacks
+////
+void cb_st3(const SteadyTimerEvent & event) {
+  CallRecorder::markCalled("testCARMANodeHandleSteadyTimers","::cb_st3");
+}
+void cb_st4(const SteadyTimerEvent & event) {
+  CallRecorder::markCalled("testCARMANodeHandleSteadyTimers","::cb_st4");
+}
+////
+// Timer Free Callbacks
+////
+void cb_t5(const TimerEvent & event) {
+  CallRecorder::markCalled("testCARMANodeHandleTimers","::cb_t5");
+}
+void cb_t6(const TimerEvent & event) {
+  CallRecorder::markCalled("testCARMANodeHandleTimers","::cb_t6");
+}
+////
+// WallTimer Free Callbacks
+////
+void cb_wt3(const WallTimerEvent & event) {
+  CallRecorder::markCalled("testCARMANodeHandleWallTimers","::cb_wt3");
+}
+void cb_wt4(const WallTimerEvent & event) {
+  CallRecorder::markCalled("testCARMANodeHandleWallTimers","::cb_wt4");
+}
+
+// Functor object used in testCARMANodeHandleTimers
+class TimerFunctor {
+  public:
+    std::string unique_obj_name_ = "";
+    std::string unique_test_name_ = "";
+  void operator () (const TimerEvent & event) { 
+    CallRecorder::markCalled(unique_test_name_, "TimerFunctor:" + unique_obj_name_ + ":cb_t1");
+  } 
+};
+
+/**
+ * Helper function will wait until the requested function has been called the requested number of times
+ */ 
+void awaitFunctionCall(const std::string& testKey, const std::string& functionKey, unsigned int callCount, double timeout_sec) {
+  Duration timeout(timeout_sec);
+  Time startTime = Time::now(); // Wait for connection
+  Rate r(5);
+  while (ros::ok() && CallRecorder::callCount(testKey, functionKey) < callCount && (Time::now() - startTime) < timeout) {
+    ros::spinOnce();
+    r.sleep();
+  }
+}
+
+TEST(CARMANodeHandleTests, testCARMANodeHandleConstructor)
+{
+  CARMANodeHandle cnh;
+
+  cnh.setExceptionCallback([](const std::exception& exp) -> void {});
+
+  cnh.setShutdownCallback([]() -> void {});
+
+  cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {});
+
+  cnh.setSpinCallback([]() -> bool {return true;});
+
+  CARMANodeHandle cnh2(cnh);
+
+  CARMANodeHandle cnh3(cnh, "h");
+
+  M_string remappings;
+
+  remappings["gh"]="fh";
+
+  CARMANodeHandle	cnh4(cnh,
+    "g",
+    remappings 
+  );
+}
+
+TEST(CARMANodeHandleTests, testCARMANodeHandleSubscriber)
+{
+  CallRecorder::clearHistory("testCARMANodeHandleSubscriber");
+  CARMANodeHandle cnh;
+
+  A a;
+  a.unique_obj_name_ = "a";
+  a.unique_test_name_ = "testCARMANodeHandleSubscriber";
+  boost::shared_ptr<A> aPtr = boost::make_shared<A>(a);
+
+  Subscriber s1 = cnh.subscribe ("t", 1, &A::cb_1, &a);
+  
+  Subscriber s2 = cnh.subscribe ("t", 1, &A::cb_2, &a);
+  
+  Subscriber s3 = cnh.subscribe ("t", 1, &A::cb_3, &a);
+
+  Subscriber s4 = cnh.subscribe ("t", 1, &A::cb_4, &a);
+
+  Subscriber s5 = cnh.subscribe ("t", 1, &A::cb_5, aPtr);
+
+  Subscriber s6 = cnh.subscribe ("t", 1, &A::cb_6, aPtr);
+
+  Subscriber s7 = cnh.subscribe ("t", 1, &A::cb_7, aPtr);
+
+  Subscriber s8 = cnh.subscribe ("t", 1, &A::cb_8, aPtr);
+
+  Subscriber s9 = cnh.subscribe ("t", 1, cb_9);
+
+  Subscriber s10 = cnh.subscribe ("t", 1, cb_10);
+  
+  Subscriber s11 = cnh.subscribe<std_msgs::Bool>("t", 1, cb_11, VoidConstPtr());
+
+  Subscriber s12 = cnh.subscribe<std_msgs::Bool, const std_msgs::Bool&>("t", 1, boost::bind(cb_12, _1));
+  
+  // NOTE: This SubscribeOptions check is just for validating the warning is printed manually
+  SubscribeOptions subOps;
+  subOps.init<std_msgs::Bool>("t", 1, boost::bind(cb_13, _1));
+  Subscriber s13 = cnh.subscribe(subOps); 
+
+  NodeHandle nh;
+  Publisher t_pub = nh.advertise<std_msgs::Bool>("t", 1);
+  std_msgs::Bool msg;
+  t_pub.publish(msg);
+
+  awaitFunctionCall("testCARMANodeHandleSubscriber", "A:a:cb_1", 1, 4);
+  
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_2"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_3"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_4"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_5"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_6"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_7"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "A:a:cb_8"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::cb_9"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::cb_10"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::cb_11"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::cb_12"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::cb_13"), 1);
+
+  Publisher p1 = cnh.advertise<std_msgs::Bool>("p", 1);
+
+  Publisher p2 = cnh.advertise<std_msgs::Bool>("p", 1,
+    [](const SingleSubscriberPublisher& ssp) -> void {CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::lambda-p1");},
+    [](const SingleSubscriberPublisher& ssp) -> void {CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::lambda-p2");}
+  );
+
+  AdvertiseOptions adv_ops;
+  adv_ops.init<std_msgs::Bool>("p", 1, 
+    [](const SingleSubscriberPublisher& ssp) -> void {CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::lambda-p3");},
+    [](const SingleSubscriberPublisher& ssp) -> void {CallRecorder::markCalled("testCARMANodeHandleSubscriber", "::lambda-p4");}
+  );
+  Publisher p3 = cnh.advertise(adv_ops);
+
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p1"), 0);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p2"), 0);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p3"), 0);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p4"), 0);
+
+  Subscriber s14 = nh.subscribe ("p", 10, cb_14);
+
+  awaitFunctionCall("testCARMANodeHandleSubscriber", "::lambda-p1", 1, 4);
+
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p2"), 0);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p3"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p4"), 0);
+
+  std_msgs::Bool boolMsg;
+  p1.publish(boolMsg);
+  p2.publish(boolMsg);
+  p3.publish(boolMsg);
+
+  awaitFunctionCall("testCARMANodeHandleSubscriber", "::cb_14", 3, 8);
+
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::cb_14"), 3);
+
+  s14.shutdown(); // Unsubscribe
+
+  awaitFunctionCall("testCARMANodeHandleSubscriber", "::lambda-p2", 1, 4);
+
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p2"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p3"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSubscriber", "::lambda-p4"), 1);
+
+}
+
+TEST(CARMANodeHandleTests, testCARMANodeHandleServices)
+{
+  CallRecorder::clearHistory("testCARMANodeHandleServices");
+
+  A a;
+  a.unique_obj_name_ = "a";
+  a.unique_test_name_ = "testCARMANodeHandleServices";
+  boost::shared_ptr<A> aPtr = boost::make_shared<A>(a);
+
+  CARMANodeHandle srv_cnh;
+  ros::CallbackQueue srv_queue;
+  srv_cnh.setCallbackQueue(&srv_queue);
+  ros::AsyncSpinner service_spinner(1, &srv_queue);
+  service_spinner.start();
+
+  ServiceServer ss1 = srv_cnh.advertiseService ("s1", &A::cb_s1, &a);
+  
+  ServiceServer ss2 = srv_cnh.advertiseService ("s2", &A::cb_s2, &a);
+  
+  ServiceServer ss3 = srv_cnh.advertiseService ("s3", &A::cb_s3, aPtr);
+  
+  ServiceServer ss4 = srv_cnh.advertiseService ("s4", &A::cb_s4, aPtr);
+  
+  ServiceServer ss5 = srv_cnh.advertiseService ("s5", cb_s5);
+  
+  ServiceServer ss6 = srv_cnh.advertiseService ("s6", cb_s6);
+  
+  ServiceServer ss7 = srv_cnh.advertiseService<std_srvs::SetBool::Request, std_srvs::SetBool::Response>("s7", cb_s7, VoidConstPtr());
+  
+  ServiceServer ss8 = srv_cnh.advertiseService<ServiceEvent<std_srvs::SetBool::Request, std_srvs::SetBool::Response>>("s8", cb_s8, VoidConstPtr());
+  
+  // NOTE: This SubscribeOptions check is just for validating the warning is printed manually
+  AdvertiseServiceOptions srv_ops;
+  srv_ops.init<std_srvs::SetBool::Request, std_srvs::SetBool::Response>("s9", cb_s9); 
+  ServiceServer ss9 = srv_cnh.advertiseService (srv_ops);
+
+  ros::Duration srv_timeout(4);
+  ros::service::waitForService("s1", srv_timeout);
+  ros::service::waitForService("s2", srv_timeout);
+  ros::service::waitForService("s3", srv_timeout);
+  ros::service::waitForService("s4", srv_timeout);
+  ros::service::waitForService("s5", srv_timeout);
+  ros::service::waitForService("s6", srv_timeout);
+  ros::service::waitForService("s7", srv_timeout);
+  ros::service::waitForService("s8", srv_timeout);
+  ros::service::waitForService("s9", srv_timeout);
+
+  std_srvs::SetBool srv_msg;
+  ros::service::call("s1", srv_msg);
+  ros::service::call("s2", srv_msg);
+  ros::service::call("s3", srv_msg);
+  ros::service::call("s4", srv_msg);
+  ros::service::call("s5", srv_msg);
+  ros::service::call("s6", srv_msg);
+  ros::service::call("s7", srv_msg);
+  ros::service::call("s8", srv_msg);
+  ros::service::call("s9", srv_msg);
+  // Service calls should block so no need to wait for callbacks here
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "A:a:cb_s1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "A:a:cb_s2"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "A:a:cb_s3"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "A:a:cb_s4"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "::cb_s5"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "::cb_s6"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "::cb_s7"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "::cb_s8"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleServices", "::cb_s9"), 1);
+
+  service_spinner.stop();
+}
+
+TEST(CARMANodeHandleTests, testCARMANodeHandleSteadyTimers)
+{
+  CallRecorder::clearHistory("testCARMANodeHandleSteadyTimers");
+
+  A a;
+  a.unique_obj_name_ = "a";
+  a.unique_test_name_ = "testCARMANodeHandleSteadyTimers";
+  boost::shared_ptr<A> aPtr = boost::make_shared<A>(a);
+
+  CARMANodeHandle st_cnh;
+
+  ros::WallDuration timerLength(1); // 1sec
+  SteadyTimer st1 = st_cnh.createSteadyTimer (timerLength, &A::cb_st1, &a, true);
+
+  SteadyTimer st2 = st_cnh.createSteadyTimer (timerLength, &A::cb_st2, aPtr, true);
+
+  SteadyTimer st3 = st_cnh.createSteadyTimer (timerLength, boost::bind(cb_st3, _1), true);
+
+  SteadyTimerOptions st_ops(timerLength, boost::bind(cb_st4, _1), NULL, true);
+  SteadyTimer st4 = st_cnh.createSteadyTimer (st_ops);
+
+  awaitFunctionCall("testCARMANodeHandleSteadyTimers", "A:a:cb_st1", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleSteadyTimers", "A:a:cb_st2", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleSteadyTimers", "::cb_st3", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleSteadyTimers", "::cb_st4", 1, 4);
+
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSteadyTimers", "A:a:cb_st1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSteadyTimers", "A:a:cb_st2"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSteadyTimers", "::cb_st3"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSteadyTimers", "::cb_st4"), 1);
+}
+
+TEST(CARMANodeHandleTests, testCARMANodeHandleTimers)
+{
+  CallRecorder::clearHistory("testCARMANodeHandleTimers");
+
+  A a;
+  a.unique_obj_name_ = "a";
+  a.unique_test_name_ = "testCARMANodeHandleTimers";
+  boost::shared_ptr<A> aPtr = boost::make_shared<A>(a);
+
+  CARMANodeHandle t_cnh;
+
+  TimerFunctor tf;
+  tf.unique_obj_name_ = "tf";
+  tf.unique_test_name_ = "testCARMANodeHandleTimers";
+
+  ros::Rate tR(1);
+  ros::Duration timerTimeout(1);
+
+  Timer t1 = t_cnh.createTimer (tR, tf, tf, true);
+
+  Timer t2 = t_cnh.createTimer (timerTimeout, &A::cb_t2, &a, true);
+
+  Timer t3 = t_cnh.createTimer (timerTimeout, &A::cb_t3, &a, true);
+
+  Timer t4 = t_cnh.createTimer (timerTimeout, &A::cb_t4, aPtr, true);
+
+  Timer t5 = t_cnh.createTimer (timerTimeout, boost::bind(cb_t5, _1), true);
+
+  TimerOptions t_ops(timerTimeout, boost::bind(cb_t6, _1), NULL, true);
+  
+  Timer t6 = t_cnh.createTimer (t_ops);
+
+  awaitFunctionCall("testCARMANodeHandleTimers", "TimerFunctor:tf:cb_t1", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleTimers", "A:a:cb_t2", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleTimers", "A:a:cb_t3", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleTimers", "A:a:cb_t4", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleTimers", "::cb_t5", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleTimers", "::cb_t6", 1, 4);
+
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleTimers", "TimerFunctor:tf:cb_t1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleTimers", "A:a:cb_t2"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleTimers", "A:a:cb_t3"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleTimers", "A:a:cb_t4"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleTimers", "::cb_t5"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleTimers", "::cb_t6"), 1);
+}
+
+TEST(CARMANodeHandleTests, testCARMANodeHandleWallTimers)
+{
+  CallRecorder::clearHistory("testCARMANodeHandleWallTimers");
+
+  A a;
+  a.unique_obj_name_ = "a";
+  a.unique_test_name_ = "testCARMANodeHandleWallTimers";
+  boost::shared_ptr<A> aPtr = boost::make_shared<A>(a);
+
+  CARMANodeHandle wt_cnh;
+  ros::WallDuration wallTimeout(1);
+  WallTimer wt1 = wt_cnh.createWallTimer (wallTimeout, &A::cb_wt1, &a, true);
+
+  WallTimer wt2 = wt_cnh.createWallTimer (wallTimeout, &A::cb_wt2, aPtr, true);
+
+  WallTimer wt3 = wt_cnh.createWallTimer (wallTimeout, boost::bind(cb_wt3, _1), true);
+
+  ros::WallTimerOptions wt_ops(wallTimeout, boost::bind(cb_wt4, _1), NULL, true);
+  WallTimer wt4 = wt_cnh.createWallTimer (wt_ops);
+
+  awaitFunctionCall("testCARMANodeHandleWallTimers", "A:a:cb_wt1", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleWallTimers", "A:a:cb_wt2", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleWallTimers", "::cb_wt3", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleWallTimers", "::cb_wt4", 1, 4);
+
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleWallTimers", "A:a:cb_wt1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleWallTimers", "A:a:cb_wt2"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleWallTimers", "::cb_wt3"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleWallTimers", "::cb_wt4"), 1);
+}
+
+TEST (CARMANodeHandleTests, testCARMANodeHandleSystemAlert) {
+  CallRecorder::clearHistory("testCARMANodeHandleSystemAlert");
+  CARMANodeHandle cnh;
+
+  cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {
+    CallRecorder::markCalled("testCARMANodeHandleSystemAlert","::alertLambda1");
+  });
+
+  cav_msgs::SystemAlert msg;
+  cnh.publishSystemAlert(msg);
+  awaitFunctionCall("testCARMANodeHandleSystemAlert", "::alertLambda1", 1, 4);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSystemAlert", "::alertLambda1"), 1);
+}
+
+TEST (CARMANodeHandleTests, testCARMANodeHandleExceptionAndShutdown) {
+  CallRecorder::clearHistory("testCARMANodeHandleExceptionAndShutdown");
+  CARMANodeHandle cnh;
+
+  cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {
+    CallRecorder::markCalled("testCARMANodeHandleExceptionAndShutdown","::alertLambda1");
+    throw std::invalid_argument("This is not a real exception and is coming from a unit test");
+  });
+
+  cnh.setExceptionCallback([](const std::exception& e) -> void {
+    CallRecorder::markCalled("testCARMANodeHandleExceptionAndShutdown","::exceptionLambda1");
+  });
+
+  cnh.setShutdownCallback([]() -> void {
+    CallRecorder::markCalled("testCARMANodeHandleExceptionAndShutdown","::shutdownLambda1");
+  });
+
+  // Disable ros::shutdown to allow for testing
+  CARMANodeHandle::allowNodeShutdown(false);
+
+  cav_msgs::SystemAlert msg;
+  cnh.publishSystemAlert(msg);
+  awaitFunctionCall("testCARMANodeHandleExceptionAndShutdown", "::exceptionLambda1", 1, 4);
+  awaitFunctionCall("testCARMANodeHandleExceptionAndShutdown", "::shutdownLambda1", 1, 4);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleExceptionAndShutdown", "::exceptionLambda1"), 1);
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleExceptionAndShutdown", "::shutdownLambda1"), 1);
+}
+
+TEST (CARMANodeHandleTests, testCARMANodeHandleSpin) {
+  CallRecorder::clearHistory("testCARMANodeHandleSpin");
+  CARMANodeHandle cnh;
+
+  cnh.setExceptionCallback([](const std::exception& exp) -> void {});
+
+  cnh.setShutdownCallback([]() -> void {});
+
+  cnh.setSystemAlertCallback([](const cav_msgs::SystemAlertConstPtr& msg) -> void {});
+
+  cnh.setSpinCallback([]() -> bool {
+    static int callCount = 0;
+    CallRecorder::markCalled("testCARMANodeHandleSpin","::spinLambda1");
+    callCount++;
+    if (callCount >= 4) {
+      return false;
+    }
+    return true;
+  });
+
+  // Disable ros::shutdown to allow for testing
+  CARMANodeHandle::allowNodeShutdown(false);
+  CARMANodeHandle::resetShutdownStatus();
+
+  cnh.spin(); // Blocks until spin callback returns false
+  ASSERT_EQ(CallRecorder::callCount("testCARMANodeHandleSpin", "::spinLambda1"), 4);
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "carma_node_tests", ros::init_options::AnonymousName);
+
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/carma_utils/test/carma_utils/CallRecorder.h
+++ b/carma_utils/test/carma_utils/CallRecorder.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018-2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License") { you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <unordered_map>
+#include <algorithm>
+#include <mutex>
+#include <iostream>
+
+/**
+ * Helper functions for recording calls without use of Mocks in unit tests. 
+ * User must call markCalled(test name, function name) inside each function call
+ * callCount can be used to get the number of times a function was called
+ * clearHistory can be used to clear the history of a specific test
+ * 
+ * These functions are thread safe and support usage in multiple test cases
+ * 
+ * Functions should be referred to using the pattern Class::obj::function for example "A::a::getValue"
+ * Free functions should be referred to without class and obj designations such as "::freeFunc"
+ * These patterns help keep names more unique
+ */ 
+namespace CallRecorder {
+
+  std::mutex map_mutex_; // Make recorder thread safe incase there is multi-threading of unit tests
+  std::unordered_map<std::string, std::unordered_map<std::string, unsigned int>> callMap_;
+  // Mark function as called
+  void markCalled(const std::string& testKey, const std::string& fullFunctionName) { // Class::obj::function
+    std::lock_guard<std::mutex> lock(map_mutex_);
+
+    if (callMap_.find(testKey) == callMap_.end()) {
+      std::unordered_map<std::string, unsigned int> calls;
+      callMap_[testKey] = calls;
+    }
+    auto test_map = callMap_[testKey];
+
+    if (test_map.find(fullFunctionName) == test_map.end()) {
+      test_map[fullFunctionName] = 0;
+    }
+    test_map[fullFunctionName] += 1;
+
+    callMap_[testKey] = test_map;
+  }
+  // Get the call count of a function
+  unsigned int callCount(const std::string& testKey, const std::string& fullFunctionName) {
+    std::lock_guard<std::mutex> lock(map_mutex_);
+    auto test_calls_map = callMap_[testKey];
+    if (test_calls_map.find(fullFunctionName) == test_calls_map.end()) {
+      return 0;
+    }
+    return test_calls_map[fullFunctionName];
+  }
+  // Clear function call history for a specific test
+  bool clearHistory(const std::string& testKey) {
+    std::lock_guard<std::mutex> lock(map_mutex_);
+    callMap_[testKey].clear();
+    callMap_.erase(testKey);
+  }
+};


### PR DESCRIPTION
# PR Details
## Description
This PR adds a carma_utils package containing CARMANodeHandle.h/.cpp files. The CARMANodeHandle extends the roscpp NodeHandle and wraps all callbacks (sub, pub, srvs, timers) in exception handling logic. Users of this class will still interact with these functions as normal. However, to support the exception handling additional functionality is provided. 

By default a static subscription to "system_alert" is created when the first CARMANodeHandle() is created. This means users do not need to setup this subscriber themselves. However, they can still provide a callback for this subscription and publish to that topic using the provided setSystemAlertCallback and publishSystemAlert functions. 

In addition the user can add callbacks for exceptions and shutdown requests. 

There is a spin() method provided which is meant to replace calls to ros::spin() and while loops containing ros::spinOnce(); The spin method contains its own while loop which runs at a configurable rate and will trigger a callback the user has defined using the setSpinCallback() function during each loop. Just like ros::spin() this function will block until a shutdown is triggered. The user is still able to use any other non-synchronous spinner with their pub/sub/srv/timers if they wish.

Currently the class exists under the ros namespace. This is convenient, but I'm not sure it is the best idea. Let me know your thoughts.  

## Related Issue

Resolves #259 

## Motivation and Context

Improve development efficiency and consistency. 

## How Has This Been Tested?

Extensive unit tests of every public function

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
