### PR TITLE
Fix usage of CARMANodeHandle exceptions and compilation errors

### DIFF
--- a/trajectory_executor/config/roscpp_log.config
+++ b/trajectory_executor/config/roscpp_log.config
@@ -1,2 +1,2 @@
 # Set the default ros output to warning and higher
-log4j.logger.ros=DEBUG
+log4j.logger.ros=INFO

--- a/trajectory_executor/src/test/test_utils.h
+++ b/trajectory_executor/src/test/test_utils.h
@@ -31,7 +31,7 @@ class TrajectoryExecutorTestSuite : public ::testing::Test
     public:
         TrajectoryExecutorTestSuite() {
             _nh = ros::NodeHandle();
-            traj_pub = _nh.advertise<cav_msgs::TrajectoryPlan>("/trajectory", 5);
+            traj_pub = _nh.advertise<cav_msgs::TrajectoryPlan>("/trajectory_executor_node/trajectory", 5);
             traj_sub = _nh.subscribe<cav_msgs::TrajectoryPlan>("/carma/guidance/control_plugins/pure_pursuit/trajectory", 100, 
             &TrajectoryExecutorTestSuite::trajEmitCallback, this);
             sys_alert_sub = _nh.subscribe<cav_msgs::SystemAlert>("/system_alert", 100, 

--- a/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
+++ b/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
@@ -91,11 +91,19 @@ namespace trajectory_executor
                     description_builder << "No match found for control plugin " 
                         << control_plugin << " at point " 
                         << _timesteps_since_last_traj << " in current trajectory!";
-                    throw description_builder.str();
+                    cav_msgs::SystemAlert alert;
+                    alert.type = cav_msgs::SystemAlert::FATAL;
+                    alert.description = description_builder.str();
+
+                    _public_nh->publishSystemAlert(alert);
                 }
                 _timesteps_since_last_traj++;
             } else {
-                throw "Ran out of trajectory data to consume!");
+                cav_msgs::SystemAlert alert;
+                alert.type = cav_msgs::SystemAlert::FATAL;
+                alert.description = "Ran out of trajectory data to consume!";
+
+                _public_nh->publishSystemAlert(alert);
             }
         } else {
             ROS_DEBUG("Awaiting initial trajectory publication...");


### PR DESCRIPTION
Thanks for the contribution, this is awesome.

# PR Details

## Description

Fixed leftover bugs in trajectory executor:

1. Exceptions were throw with the expectation that CARMANodeHandle would catch them and publish SystemAlert, but that only applies if you're using a specific callback from CARMANodeHandle. Since we're just using spin itself, we want to use `publishSystemAlert`.
2. Fix misc compilation issues that went undetected because I was re-running the already built unit tests by accident.
3. Fix unit test topic names broken by shifting to using a private node handle

## How Has This Been Tested?

Unit tests built clean and re-run locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
