### PR TITLE
Fix ecef unit test quaternion usage

### DIFF
--- a/sensor_fusion/test/transform_maintainer_test.cpp
+++ b/sensor_fusion/test/transform_maintainer_test.cpp
@@ -132,13 +132,13 @@ TEST(MapToECEFTransformTest, example1)
   tf2::Transform tf_map_to_baselink(map_to_baselink_rot, map_to_baselink_translation);
 
   tf2::Transform tf_map_to_ecef = (tf_map_to_baselink * ((tf_ecef_to_ned * tf_ned_to_baselink).inverse())).inverse();
-  std::cerr << tf_map_to_ecef.getOrigin().getX() << std::endl;
-  std::cerr << tf_map_to_ecef.getOrigin().getY() << std::endl;
-  std::cerr << tf_map_to_ecef.getOrigin().getZ() << std::endl;
-  std::cerr << tf_map_to_ecef.getRotation().getAxis().getX() << std::endl;
-  std::cerr << tf_map_to_ecef.getRotation().getAxis().getY() << std::endl;
-  std::cerr << tf_map_to_ecef.getRotation().getAxis().getZ() << std::endl;
-  std::cerr << tf_map_to_ecef.getRotation().getW() << std::endl;
+  std::cerr << std::setprecision(20) << tf_map_to_ecef.getOrigin().getX() << std::endl;
+  std::cerr << std::setprecision(20) << tf_map_to_ecef.getOrigin().getY() << std::endl;
+  std::cerr << std::setprecision(20) << tf_map_to_ecef.getOrigin().getZ() << std::endl;
+  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getX() << std::endl;
+  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getY() << std::endl;
+  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getZ() << std::endl;
+  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getW() << std::endl;
   
 }
 

--- a/sensor_fusion/test/transform_maintainer_test.cpp
+++ b/sensor_fusion/test/transform_maintainer_test.cpp
@@ -133,12 +133,12 @@ TEST(MapToECEFTransformTest, example1)
 
   tf2::Transform tf_map_to_ecef = (tf_map_to_baselink * ((tf_ecef_to_ned * tf_ned_to_baselink).inverse())).inverse();
   std::cerr << std::setprecision(20) << tf_map_to_ecef.getOrigin().getX() << std::endl;
-  std::cerr << std::setprecision(20) << tf_map_to_ecef.getOrigin().getY() << std::endl;
-  std::cerr << std::setprecision(20) << tf_map_to_ecef.getOrigin().getZ() << std::endl;
-  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getX() << std::endl;
-  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getY() << std::endl;
-  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getZ() << std::endl;
-  std::cerr << std::setprecision(20) << tf_map_to_ecef.getRotation().getW() << std::endl;
+  std::cerr << tf_map_to_ecef.getOrigin().getY() << std::endl;
+  std::cerr << tf_map_to_ecef.getOrigin().getZ() << std::endl;
+  std::cerr << tf_map_to_ecef.getRotation().getX() << std::endl;
+  std::cerr << tf_map_to_ecef.getRotation().getY() << std::endl;
+  std::cerr << tf_map_to_ecef.getRotation().getZ() << std::endl;
+  std::cerr << tf_map_to_ecef.getRotation().getW() << std::endl;
   
 }
 


### PR DESCRIPTION
# PR Details

## Description

The unit test for computing map to ECEF transforms was incorrectly accessing quaternion data. This resolves the access method. In addition it increases the print precision. 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
