### PR TITLE
Remap new static topics in ui.launch

### DIFF
--- a/carmajava/launch/ui.launch
+++ b/carmajava/launch/ui.launch
@@ -51,7 +51,13 @@
   <remap from="velocity" to="$(arg INTR_NS)/gnss/velocity"/>
   <remap from="driver_discovery" to="$(arg INTR_NS)/driver_discovery"/>
   <remap from="get_drivers_with_capabilities" to="$(arg INTR_NS)/get_drivers_with_capabilities"/>
-
+  <remap from="controller/robotic_status" to="/hardware_interface/controller/robot_status"/>
+  <remap from="controller/vehicle_cmd" to="/hardware_interface/controller/vehicle_cmd"/>
+  <remap from="comms/outbound_binary_msg" to="/hardware_interface/comms/outbound_binary_msg"/>
+  <remap from="comms/inbound_binary_msg" to="/hardware_interface/comms/inbound_binary_msg"/>
+  <remap from="can/engine_speed" to="/hardware_interface/can/engine_speed"/>
+  <remap from="can/speed" to="/hardware_interface/can/speed"/>
+  <remap from="can/acc_engaged" to="/hardware_interface/can/acc_engaged"/>
 
   <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
     <arg name="port" value="9090"/>


### PR DESCRIPTION
# PR Details

## Description

Now that the UI is using static topics instead of going through the interface manager this PR properly remaps those topics to their actual location.

## How Has This Been Tested?

Tested locally by running `carma_src.launch` and verifying that the remapped topics appear to operate as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
