### PR TITLE
Update Autoware state topic name

### DIFF
--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -50,6 +50,7 @@
   <remap from="/controller/cmd_longitudinal_effort" to="$(arg INTR_NS)/controller/cmd_longitudinal_effort"/>
   <remap from="/controller/cmd_speed" to="$(arg INTR_NS)/controller/cmd_speed"/>
   <remap from="enable_robotic" to="$(arg INTR_NS)/controller/enable_robotic"/>
+  <remap from="state" to="autoware_state"/>
 
   <remap from="ui_instructions" to="$(arg UI_NS)/ui_instructions"/>
 


### PR DESCRIPTION
# PR Details
Remap autoware state topic to avoid conflict with CARMA guidance state topic.
## Description
Based on Kyle's input, some autoware component listen to a topic named "state". When we put those component into Guidance namespace, it becomes the same topic name as CARMA guidance state machine topic: guidance/state. To avoid conflict, we remap the Autoware state topic into "autoware_state" in the guidance launch file.
## Related Issue
N/A
## Motivation and Context
N/A
## How Has This Been Tested?
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
