### PR TITLE
Feature/ui integration node state emulation

### DIFF
--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -46,11 +46,11 @@
   <remap from="/republish/cmd_longitudinal_effort" to="$(arg INTR_NS)/controller/cmd_longitudinal_effort"/>
   <remap from="/republish/cmd_speed" to="$(arg INTR_NS)/controller/cmd_speed"/>
   <remap from="robot_enabled" to="$(arg INTR_NS)/controller/robot_enabled"/>
+  <remap from="robot_status" to="/hardware_interface/controller/robot_status"/>
   <remap from="/controller/cmd_lateral" to="$(arg INTR_NS)/controller/cmd_lateral"/>
   <remap from="/controller/cmd_longitudinal_effort" to="$(arg INTR_NS)/controller/cmd_longitudinal_effort"/>
   <remap from="/controller/cmd_speed" to="$(arg INTR_NS)/controller/cmd_speed"/>
   <remap from="enable_robotic" to="$(arg INTR_NS)/controller/enable_robotic"/>
-  <remap from="state" to="autoware_state"/>
 
   <remap from="ui_instructions" to="$(arg UI_NS)/ui_instructions"/>
 
@@ -115,7 +115,9 @@
   <!-- Lane Planner -->
   <node pkg="lane_planner" type="lane_rule" name="lane_rule" />
   <node pkg="lane_planner" type="lane_stop" name="lane_stop" />
-  <node pkg="lane_planner" type="lane_select" name="lane_select" />
+  <node pkg="lane_planner" type="lane_select" name="lane_select">
+      <remap from="state" to="autoware_state"/>
+  </node>
 
   <!-- AStar Planner -->
   <include file="$(find waypoint_planner)/launch/astar_avoid.launch" />

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -46,7 +46,7 @@
   <remap from="/republish/cmd_longitudinal_effort" to="$(arg INTR_NS)/controller/cmd_longitudinal_effort"/>
   <remap from="/republish/cmd_speed" to="$(arg INTR_NS)/controller/cmd_speed"/>
   <remap from="robot_enabled" to="$(arg INTR_NS)/controller/robot_enabled"/>
-  <remap from="robot_status" to="/hardware_interface/controller/robot_status"/>
+  <remap from="robot_status" to="$(arg INTR_NS)/controller/robot_status"/>
   <remap from="/controller/cmd_lateral" to="$(arg INTR_NS)/controller/cmd_lateral"/>
   <remap from="/controller/cmd_longitudinal_effort" to="$(arg INTR_NS)/controller/cmd_longitudinal_effort"/>
   <remap from="/controller/cmd_speed" to="$(arg INTR_NS)/controller/cmd_speed"/>

--- a/ui_integration/include/ui_integration/ui_integration_worker.hpp
+++ b/ui_integration/include/ui_integration/ui_integration_worker.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <ros/ros.h>
+#include <atomic>
 #include <carma_utils/CARMAUtils.h>
 #include <cav_srvs/PluginList.h>
 #include <cav_srvs/PluginActivation.h>
@@ -25,6 +26,8 @@
 #include <cav_srvs/SetEnableRobotic.h>
 #include <cav_msgs/PluginList.h>
 #include <std_msgs/Bool.h>
+#include <cav_msgs/GuidanceState.h>
+#include <cav_msgs/RobotEnabled.h>
 
 namespace ui_integration
 {
@@ -48,6 +51,7 @@ namespace ui_integration
             bool active_plugin_cb(cav_srvs::PluginListRequest& req, cav_srvs::PluginListResponse& res);
             bool activate_plugin_cb(cav_srvs::PluginActivationRequest& req, cav_srvs::PluginActivationResponse& res);
             bool guidance_acivation_cb(cav_srvs::SetGuidanceActiveRequest& req, cav_srvs::SetGuidanceActiveResponse& res);
+            void robot_status_cb(cav_msgs::RobotEnabled msg);
 
             // Helper functions
             void populate_plugin_list_response(cav_srvs::PluginListResponse& res);
@@ -60,12 +64,18 @@ namespace ui_integration
 
             // Publishers
             ros::Publisher plugin_publisher_;
+            ros::Publisher state_publisher_;
             ros::ServiceClient enable_client_;
+
+            // Subscribers
+            ros::Subscriber robot_status_subscriber_;
 
             // Node handles
             ros::CARMANodeHandle nh_, pnh_;
 
             std::string plugin_name_;
             std::string plugin_version_;
+
+            std::atomic<bool> guidance_activated_;
     };
 }


### PR DESCRIPTION
# PR Details

## Description

Add a small bit of state tracking logic to `ui_integration` to facilitate the status reporting of the button on the web UI.  

## Motivation and Context

Enables the usage of the web UI CAV button to report the status of the vehicle. Supports ready, active, and engaged states.

## How Has This Been Tested?

Ran locally with `roslaunch carma carma_src.launch`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
