### PR TITLE
Fix voxel grid remappings and add missing autoware run dependancies

### DIFF
--- a/carma_build
+++ b/carma_build
@@ -39,7 +39,7 @@ rebuild_carma=false
 carma_build_args=""
 autoware_build_args=""
 # The list of packages which are required by carma from autoware
-AUTOWARE_PACKAGE_SELECTION="map_tools lidar_localizer map_file deadreckoner points_downsampler lane_planner waypoint_maker autoware_msgs autoware_config_msgs"
+AUTOWARE_PACKAGE_SELECTION="map_tools lidar_localizer map_file deadreckoner points_downsampler points_preprocessor lane_planner waypoint_maker autoware_msgs autoware_config_msgs as"
 
 # The list of message packages used by autoware which will need to have thier rosjava artifacts generated for carma
 # Note: The order of this list is the order of compilation and therefore must account for dependancies

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -52,8 +52,6 @@
   <remap from="bestpos" to="$(arg INTR_NS)/bestpos"/>
   <remap from="dual_antenna_heading" to="$(arg INTR_NS)/gnss/dual_antenna_heading"/>
   
-  <remap from="points_raw" to="$(arg INTR_NS)/lidar/points_raw"/>
-
   <!-- <arg name="current_twist" default="current_twist" doc="Remapping of the twist topic used by the deadreckoner node"/>
   <arg name="current_odom" default="current_odom" doc="Remapping of the twist topic used by the deadreckoner node"/> -->
   <!-- Localization Package -->
@@ -89,14 +87,22 @@
 
   <!-- Deadreckoner -->
   <include file="$(find deadreckoner)/launch/deadreckoner.launch">
-    <arg name="current_twist" value="vehicle/twist" />
+    <arg name="current_twist" value="$(arg INTR_NS)/vehicle/twist" />
     <arg name="current_odom" value="vehicle/odom" />
   </include>
 
   <!-- Voxel Grid Filter -->
-  <include file="$(find points_downsampler)/launch/points_downsample.launch">
-    <arg name="node_name" value="voxel_grid_filter" />
-    <arg name="points_topic" value="points_no_ground" />
-    
+  <group>
+    <remap from="/points_raw" to="ray_ground_filter/points_no_ground"/>
+    <include file="$(find points_downsampler)/launch/points_downsample.launch">
+      <arg name="node_name" value="voxel_grid_filter" />
+    </include>
+  </group>
+
+  <!-- Ray Ground Filter -->
+  <remap from="/points_raw" to="$(arg INTR_NS)/lidar/points_raw"/>
+  <include file="$(find points_preprocessor)/launch/ray_ground_filter.launch">
+    <arg name="no_ground_point_topic" value="points_no_ground" />
+    <arg name="ground_point_topic" value="points_ground" />
   </include>
 </launch>


### PR DESCRIPTION
# PR Details

## Description
Fixes topic re-mappings for the voxel grid filter after the ray_ground_filter was added. Also adds the ssc_interface (as package) into the carma_build script. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
