### PR TITLE
Fix/update topic remapping

### DIFF
--- a/autoware_plugin/include/autoware_plugin.h
+++ b/autoware_plugin/include/autoware_plugin.h
@@ -44,9 +44,6 @@ namespace autoware_plugin
         // get a sublist of waypoints marked by desired time span
         std::vector<autoware_msgs::Waypoint> get_waypoints_in_time_boundary(std::vector<autoware_msgs::Waypoint> waypoints, double time_span);
 
-        // make an arbitaray trajectory evenly spaced
-        std::vector<cav_msgs::TrajectoryPlanPoint> even_trajectory(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory, double spacing);
-
         // postprocess traj to add plugin names and shift time origin to the current ROS time
         std::vector<cav_msgs::TrajectoryPlanPoint> post_process_traj_points(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory);
 

--- a/autoware_plugin/launch/autoware_plugin.launch
+++ b/autoware_plugin/launch/autoware_plugin.launch
@@ -15,5 +15,5 @@
 -->
 <launch>
     <rosparam command="load" file="$(find autoware_plugin)/config/parameters.yaml"/>
-    <node name="autoware_plugin" pkg="autoware_plugin" type="autoware_plugin_node"/>
+    <node name="autoware_plugin" pkg="autoware_plugin" type="autoware_plugin"/>
 </launch>

--- a/autoware_plugin/src/autoware_plugin.cpp
+++ b/autoware_plugin/src/autoware_plugin.cpp
@@ -75,7 +75,6 @@ namespace autoware_plugin
     {
         std::vector<autoware_msgs::Waypoint> partial_waypoints = get_waypoints_in_time_boundary(waypoints, trajectory_time_length_);
         std::vector<cav_msgs::TrajectoryPlanPoint> tmp_trajectory = create_uneven_trajectory_from_waypoints(partial_waypoints);
-        //std::vector<cav_msgs::TrajectoryPlanPoint> evenly_spaced_trajectory = even_trajectory(tmp_trajectory, trajectory_point_spacing_);
         std::vector<cav_msgs::TrajectoryPlanPoint> final_trajectory = post_process_traj_points(tmp_trajectory);
         return final_trajectory;
     }
@@ -154,37 +153,6 @@ namespace autoware_plugin
             }
         }
         return sublist;
-    }
-
-    std::vector<cav_msgs::TrajectoryPlanPoint> AutowarePlugin::even_trajectory(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory, double time_spacing)
-    {
-        std::vector<cav_msgs::TrajectoryPlanPoint> res;
-        res.push_back(trajectory[0]);
-        double tp_timestamp = 0.0 + time_spacing * 1e9;
-        int next_traj_point_index = 1;
-        while(next_traj_point_index < trajectory.size())
-        {
-            if(trajectory[next_traj_point_index].target_time < tp_timestamp)
-            {
-                next_traj_point_index++;
-            }
-            else
-            {
-                cav_msgs::TrajectoryPlanPoint new_tp;
-                new_tp.target_time = tp_timestamp;
-                double time_elapsed_precentage = (tp_timestamp - trajectory[next_traj_point_index - 1].target_time) / (trajectory[next_traj_point_index].target_time - trajectory[next_traj_point_index - 1].target_time);
-
-                new_tp.x = trajectory[next_traj_point_index - 1].x + time_elapsed_precentage * (trajectory[next_traj_point_index].x - trajectory[next_traj_point_index - 1].x);
-
-                new_tp.y = trajectory[next_traj_point_index - 1].y + time_elapsed_precentage * (trajectory[next_traj_point_index].y - trajectory[next_traj_point_index - 1].y);
-
-                res.push_back(new_tp);
-
-
-                tp_timestamp += time_spacing * 1e9;
-            }
-        }
-        return res;
     }
 
     std::vector<cav_msgs::TrajectoryPlanPoint> AutowarePlugin::post_process_traj_points(std::vector<cav_msgs::TrajectoryPlanPoint> trajectory)

--- a/autoware_plugin/src/autoware_plugin.cpp
+++ b/autoware_plugin/src/autoware_plugin.cpp
@@ -182,5 +182,7 @@ namespace autoware_plugin
             trajectory[i].planner_plugin_name = "autoware";
             trajectory[i].target_time += current_nsec;
         }
+
+        return trajectory;
     }
 }

--- a/autoware_plugin/src/autoware_plugin.cpp
+++ b/autoware_plugin/src/autoware_plugin.cpp
@@ -53,7 +53,8 @@ namespace autoware_plugin
             return;
         }
         cav_msgs::TrajectoryPlan trajectory;
-        trajectory.header = msg->header;
+        trajectory.header.frame_id = msg->header.frame_id;
+        trajectory.header.stamp = ros::Time::now();
         trajectory.trajectory_id = boost::uuids::to_string(boost::uuids::random_generator()());
         trajectory.trajectory_points = compose_trajectory_from_waypoints(msg->waypoints);
         trajectory_pub_.publish(trajectory);

--- a/autoware_plugin/test/test_autoware_plugin.cpp
+++ b/autoware_plugin/test/test_autoware_plugin.cpp
@@ -232,6 +232,42 @@ TEST(AutowarePluginTest, testEvenTrajectory)
     EXPECT_NEAR(1.9336, res[6].x, 0.01);
 }
 
+TEST(AutowarePluginTest, testEvenTrajectory2)
+{
+    // compose a trajectory
+    std::vector<cav_msgs::TrajectoryPlanPoint> uneven_traj;
+    cav_msgs::TrajectoryPlanPoint tp_1;
+    tp_1.target_time = 0.0;
+    tp_1.x = 84.8083;
+    tp_1.y = -40.2181;
+    cav_msgs::TrajectoryPlanPoint tp_2;
+    tp_2.target_time = 253700845;
+    tp_2.x = 84.8916;
+    tp_2.y = -39.4143;
+    cav_msgs::TrajectoryPlanPoint tp_3;
+    tp_3.target_time = 836997889;
+    tp_3.x = 86.5672;
+    tp_3.y = -40.2168;
+    uneven_traj.push_back(tp_1);
+    uneven_traj.push_back(tp_2);
+    uneven_traj.push_back(tp_3);
+    autoware_plugin::AutowarePlugin ap;
+    std::vector<cav_msgs::TrajectoryPlanPoint> res = ap.even_trajectory(uneven_traj, 0.1);
+    for(int i = 1; i < res.size(); ++i)
+    {
+        cav_msgs::TrajectoryPlanPoint tpp = res[i - 1]; 
+        cav_msgs::TrajectoryPlanPoint tpp2 = res[i];
+        double delta_x = tpp.x - tpp2.x;
+        double delta_y = tpp.y - tpp2.y;
+        double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
+        double delta_t_second = (double)abs(tpp2.target_time - tpp.target_time) / 1e9;
+        double speed = delta_pos / delta_t_second;
+        std::cerr << "speed" << i << " : " << speed << std::endl;
+    }
+
+}
+
+
 // Run all the tests
 int main(int argc, char **argv)
 {

--- a/carma_utils/src/carma_utils/CARMANodeHandle.tpp
+++ b/carma_utils/src/carma_utils/CARMANodeHandle.tpp
@@ -60,7 +60,7 @@ namespace ros {
     boost::function< bool(C, R)> wrappedFunc = 
     [callback] (C req, R res) -> bool {
       try {
-        callback(req, res);
+        return callback(req, res);
       } catch(const std::exception& e) {
         handleException(e);
       }
@@ -76,7 +76,7 @@ namespace ros {
     boost::function< bool(E)> wrappedFunc = 
     [callback] (E event) -> bool {
       try {
-        callback(event);
+        return callback(event);
       } catch(const std::exception& e) {
         handleException(e);
       }

--- a/carmajava/launch/carma.launch
+++ b/carmajava/launch/carma.launch
@@ -28,18 +28,11 @@
   pkill -f ros
 -->
 <launch>
-
-  <!-- Set Environment Variables -->
-  <env name="ROS_IP" value="192.168.88.10"/>
-
   <!-- Override Required Paths -->
-  <arg name="CARMA_DIR" default="/opt/carma" doc="The path of the package directory"/>
-  <arg name="PARAM_DIR" default="$(arg CARMA_DIR)/params" doc="Directory of yaml parameter files"/>
-  <arg name="URDF_FILE" default="$(arg CARMA_DIR)/urdf/carma.urdf" doc="Path to the vehicle's URDF file"/>
-  <arg name="DATA_DIR"  default="$(arg CARMA_DIR)/app/mock_data" doc="Directory of driver simulation"/>
-  <arg name="SCRIPTS_DIR" default="$(arg CARMA_DIR)/app/engineering_tools" doc="The directory containing scripts for execution"/>
-  <arg name="LAUNCH_DIR" default="$(arg CARMA_DIR)/app/bin/share/carma" doc="Directory containing additional carma launch files such as driver.launch"/>
-  <arg name="log_config" default="$(arg PARAM_DIR)/log-config.properties" doc="The location of the logging config file"/>
+  <arg name="arealist_path" default="$(find aw_platform)/map/arealist.txt" doc="The path of the package directory"/>
+   <arg name="load_type" value="noupdate"/>
+   <arg name="single_pcd_path" value="$(find aw_platform)/map/pcd_map.pcd"/>
+  <arg name="area" default="1x1"/>
 
   <!-- Startup Drivers With Main CARMA System -->
   <arg name="launch_drivers" default="true" doc="True if drivers are to be launched with the CARMA Platform, overrides mock_drivers arg if false"/>
@@ -54,5 +47,5 @@
   <arg name="use_rosbag" default="true" doc="Record a rosbag for the to 26 demo"/>
 
   <!-- Include the detailed launch file and pass in new arguments -->
-  <include file="$(find carma)/carma_src.launch" pass_all_args="true"/>
+  <include file="$(find carma)/launch/carma_src.launch" pass_all_args="true"/>
 </launch>

--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -89,6 +89,9 @@
   <!-- Map file arealist.txt file to load -->
   <arg name="arealist_path" default="arealist.txt" doc="Path to the arealist.txt file which contains the paths and dimensions of each map cell to load"/>
   <arg name="area" default="5x5" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>
+  <arg name="load_type" default="noupdate" doc="Enum of the map loading approach to use. Can be 'download', 'noupdate', or 'arealist'"/> 
+  <arg name="single_pcd_path" default="pcd_map.pcd" doc="Path to the map pcd file if using the noupdate load type"/>
+  <arg name="area" default="1x1" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>
 
   <!-- Remove after TO 26 demo -->
   <arg name="use_rosbag" default="false" doc="Record a rosbag"/>
@@ -129,6 +132,8 @@
       <arg name="INTR_NS" value="$(arg INTR_NS)"/>
       <arg name="arealist_path" value="$(arg arealist_path)"/>
       <arg name="area" value="$(arg area)"/>
+      <arg name="load_type" value="$(arg load_type)"/>
+      <arg name="single_pcd_path" value="$(arg single_pcd_path)"/>
     </include>
   </group>
 

--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -160,6 +160,7 @@
       <arg name="TF_NS" value="$(arg TF_NS)"/>
       <arg name="UI_NS" value="$(arg UI_NS)"/>
       <arg name="INTR_NS" value="$(arg INTR_NS)"/>
+      <arg name="LOCZ_NS" value="$(arg LOCZ_NS)"/>
     </include>
   </group>
 

--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -88,6 +88,7 @@
   
   <!-- Map file arealist.txt file to load -->
   <arg name="arealist_path" default="arealist.txt" doc="Path to the arealist.txt file which contains the paths and dimensions of each map cell to load"/>
+  <arg name="area" default="5x5" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>
 
   <!-- Remove after TO 26 demo -->
   <arg name="use_rosbag" default="false" doc="Record a rosbag"/>
@@ -126,6 +127,8 @@
   <group ns="$(arg LOCZ_NS)">
     <include file="$(arg LAUNCH_DIR)/localization.launch">
       <arg name="INTR_NS" value="$(arg INTR_NS)"/>
+      <arg name="arealist_path" value="$(arg arealist_path)"/>
+      <arg name="area" value="$(arg area)"/>
     </include>
   </group>
 

--- a/carmajava/launch/drivers.launch
+++ b/carmajava/launch/drivers.launch
@@ -45,23 +45,36 @@ If not using simulated drivers they are activated if the respective mock argumen
 
   <!-- DSRC OBU Driver Node -->
   <include unless="$(arg mock_comms)" file="$(find dsrc_driver)/launch/dsrc_node.launch"/>
-      
-  <!-- PinPoint Driver Node -->
-  <include unless="$(arg mock_gnss)" file="$(find pinpoint)/launch/pinpoint.launch"/>
 
-  <!-- SRX CAN Driver Node -->
-  <include unless="$(arg mock_can)" file="$(find srx_can_driver)/launch/srx_can_driver_socketcan.launch">
-    <arg name="srx_can_can_device" value="can2" />
+  <!-- PACMOD Controller Driver Node -->
+  <include unless="$(arg mock_controller)" file="$(find ssc_interface_wrapper)/launch/ssc_pacmod_driver.launch">
+    <arg name="pacmod_vehicle_type" default="LEXUS_RX_450H" />
+    <arg name="use_kvaser" default="true" />
+    <arg name="kvaser_hardware_id" default="10376" />
+    <arg name="kvaser_circuit_id" default="0" />
   </include>
 
-  <!--SRX Controller Driver Node-->
-  <include unless="$(arg mock_controller)" file="$(find srx_controller)/launch/srx_controller.launch">
-    <arg name="srx_controller_can_device" value="can1"/>
+  <!-- Novatel GNSS/IMU Driver Nodes -->
+  <include unless="$(arg mock_lidar)" file="$(find novatel_gps_driver)/launch/novatel_gps_driver_eth.launch">
+    <arg name="ip" value="192.168.74.10" />
+    <arg name="port" value="2000" />
+    <arg name="imu_rate" value="100" />
+    <arg name="frame_id" value="novatel_gnss" />
+    <arg name="imu_frame_id" value="novatel_imu" />
   </include>
-      
-  <!-- SRX Radar Driver Node -->
-  <include unless="$(arg mock_radar)" file="$(find srx_objects)/launch/srx_objects_socketcan.launch">
-    <arg name="srx_objects_can_device" value="can0"/>
+
+  <!-- Velodyne Lidar Driver Nodes -->
+  <include unless="$(arg mock_lidar)" file="$(find velodyne_lidar_driver_wrapper)/launch/velodyne_lidar_driver.launch">
+    <arg name="frame_id" value="velodyne"/>
+    <arg name="device_ip" value="192.168.1.201"/>
   </include>
-	
+
+  <!-- TODO AVT Vimba Camera Left Driver Node -->
+  <!-- TODO AVT Vimba Camera Right Driver Node -->
+  <!-- TODO DelphiESR Front Driver Node -->
+  <!-- TODO Delphi Srr2 Front Left Driver Node -->
+  <!-- TODO Delphi Srr2 Front Right Driver Node -->
+  <!-- TODO Delphi Srr2 Rear Left Driver Node -->
+  <!-- TODO Delphi Srr2 Rear Right Driver Node -->
+
 </launch>

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -110,7 +110,20 @@
 
   <!-- Twist Filter -->
   <group>
+    <remap from="/accel_cmd" to="accel_cmd"/>
+    <remap from="/brake_cmd" to="brake_cmd"/>
+    <remap from="/ctrl_cmd" to="ctrl_cmd"/>
+    <remap from="/decision_maker/state" to="decision_maker/state"/>
+    <remap from="/gear_cmd" to="gear_cmd"/>
     <remap from="/twist_cmd" to="twist_cmd"/>
+    <remap from="/lamp_cmd" to="lamp_cmd"/>
+    <remap from="/mode_cmd" to="mode_cmd"/>
+    <remap from="/remote_cmd" to="remote_cmd"/>
+    <remap from="/steer_cmd" to="steer_cmd"/>
+    <remap from="/ctrl_mode" to="ctrl_mode"/>
+    <remap from="/emergency_stop" to="emergency_stop"/>
+    <remap from="/state_cmd" to="state_cmd"/>
+    <remap from="/vehicle_cmd" to="$(arg INTR_NS)/controller/vehicle_cmd"/>
     <include file="$(find waypoint_follower)/launch/twist_filter.launch"/>
   </group>
 

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -29,6 +29,7 @@
   <arg name="TF_NS" default="/transform" doc="Namespace of nodes in transform server package"/>
   <arg name="INTR_NS" default="/hardware_interface" doc="Namespace of nodes hardware interface stack"/>
   <arg name="UI_NS" default="/ui" doc="Namespace of parameters used by the ui and rosbridge"/>
+  <arg name="LOCZ_NS" default="/localization" doc="Namespace of parameters used by the ui and rosbridge"/>
   
   <!-- Remap topics from external packages -->
   <remap from="bsm" to="$(arg MSG_NS)/outgoing_bsm"/>
@@ -71,7 +72,7 @@
   <remap from="trajectory" to="plan_trajectory"/>
   <!-- TODO use arguments for top level namespace -->
   <remap from="trajectory_plan" to="/guidance/pure_pursuit/trajectory"/>
-  <remap from="current_pose" to="/localization/ndt_pose"/>
+  <remap from="current_pose" to="$(arg LOCZ_NS)/ndt_pose"/>
   <remap from="current_velocity" to="$(arg INTR_NS)/vehicle/twist"/>
   <remap from="controller/enable_robotic" to="$(arg INTR_NS)/controller/enable_robotic"/>
 

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -68,7 +68,10 @@
   <remap from="/traffic_waypoints_array" to="traffic_waypoints_array"/>
   <remap from="/red_waypoints_array" to="red_waypoints_array"/>
   <remap from="/green_waypoints_array" to="green_waypoints_array"/>
-  <remap from="state" to="autoware_state"/>
+  <remap from="trajectory" to="plan_trajectory"/>
+  <remap from="trajectory_plan" to="/guidance/pure_pursuit/trajectory"/>
+  <remap from="current_pose" to="/localization/ndt_pose"/>
+  <remap from="current_velocity" to="/hardware_interface/vehicle/twist"/>
 
   <!-- Guidance Main Node -->
   <!-- <node pkg="carma" type="guidance" name="guidance_main" args="gov.dot.fhwa.saxton.carma.guidance.GuidanceMain">
@@ -96,7 +99,7 @@
   <!-- Control Stack -->
   <!-- Waypoint Follower Config-->
   <node pkg="rostopic" type="rostopic" name="config_waypoint_follower_rostopic"
-        args="pub -l /config/waypoint_follower autoware_config_msgs/ConfigWaypointFollower '{ header: auto, param_flag: 0, velocity: 5.0, lookahead_distance: 4.0, lookahead_ratio: 2.0, minimum_lookahead_distance: 6.0, displacement_threshold: 0.0, relative_angle_threshold: 0.0 }' "
+        args="pub -l config/waypoint_follower autoware_config_msgs/ConfigWaypointFollower '{ header: auto, param_flag: 0, velocity: 5.0, lookahead_distance: 4.0, lookahead_ratio: 2.0, minimum_lookahead_distance: 6.0, displacement_threshold: 0.0, relative_angle_threshold: 0.0 }' "
   />
 
   <!-- Trajectory Executor -->
@@ -124,7 +127,9 @@
   <!-- Lane Planner -->
   <node pkg="lane_planner" type="lane_stop" name="lane_stop"/>
   <node pkg="lane_planner" type="lane_rule" name="lane_rule"/>
-  <node pkg="lane_planner" type="lane_select" name="lane_select"/>
+  <node pkg="lane_planner" type="lane_select" name="lane_select">
+      <remap from="state" to="autoware_state"/>
+  </node>
 
   <!-- AStar Planner -->
   <include file="$(find waypoint_planner)/launch/astar_avoid.launch" />

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -123,7 +123,7 @@
     <remap from="/ctrl_mode" to="ctrl_mode"/>
     <remap from="/emergency_stop" to="emergency_stop"/>
     <remap from="/state_cmd" to="state_cmd"/>
-    <remap from="/vehicle_cmd" to="$(arg INTR_NS)/controller/vehicle_cmd"/>
+    <remap from="/vehicle_cmd" to="$(arg INTR_NS)/vehicle_cmd"/>
     <include file="$(find waypoint_follower)/launch/twist_filter.launch"/>
   </group>
 

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -69,9 +69,11 @@
   <remap from="/red_waypoints_array" to="red_waypoints_array"/>
   <remap from="/green_waypoints_array" to="green_waypoints_array"/>
   <remap from="trajectory" to="plan_trajectory"/>
+  <!-- TODO use arguments for top level namespace -->
   <remap from="trajectory_plan" to="/guidance/pure_pursuit/trajectory"/>
   <remap from="current_pose" to="/localization/ndt_pose"/>
-  <remap from="current_velocity" to="/hardware_interface/vehicle/twist"/>
+  <remap from="current_velocity" to="$(arg INTR_NS)/vehicle/twist"/>
+  <remap from="controller/enable_robotic" to="$(arg INTR_NS)/controller/enable_robotic"/>
 
   <!-- Guidance Main Node -->
   <!-- <node pkg="carma" type="guidance" name="guidance_main" args="gov.dot.fhwa.saxton.carma.guidance.GuidanceMain">

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -63,6 +63,13 @@
 
   <remap from="system_alert" to="/system_alert"/>
 
+  <remap from="/base/lane_waypoints_raw" to="base/lane_waypoints_raw"/>       
+  <remap from="/lane_waypoints_array" to="lane_waypoints_array"/>
+  <remap from="/traffic_waypoints_array" to="traffic_waypoints_array"/>
+  <remap from="/red_waypoints_array" to="red_waypoints_array"/>
+  <remap from="/green_waypoints_array" to="green_waypoints_array"/>
+  <remap from="state" to="autoware_state"/>
+
   <!-- Guidance Main Node -->
   <!-- <node pkg="carma" type="guidance" name="guidance_main" args="gov.dot.fhwa.saxton.carma.guidance.GuidanceMain">
 
@@ -108,20 +115,23 @@
   />
   
   <!-- Waypoint Loader -->
-  <node pkg="waypoint_maker" type="waypoint_loader" name="waypoint_loader"/>
+  <node pkg="waypoint_maker" type="waypoint_loader" name="waypoint_loader">
+      
+  </node>
   <node pkg="waypoint_maker" type="waypoint_replanner" name="waypoint_replanner"/>
   <node pkg="waypoint_maker" type="waypoint_marker_publisher" name="waypoint_marker_publisher" />
 
   <!-- Lane Planner -->
-  <node pkg="lane_planner" type="lane_rule" name="lane_rule" />
-  <node pkg="lane_planner" type="lane_stop" name="lane_stop" />
-  <node pkg="lane_planner" type="lane_select" name="lane_select">
-      <remap from="state" to="autoware_state"/>
-  </node>
+  <node pkg="lane_planner" type="lane_stop" name="lane_stop"/>
+  <node pkg="lane_planner" type="lane_rule" name="lane_rule"/>
+  <node pkg="lane_planner" type="lane_select" name="lane_select"/>
 
   <!-- AStar Planner -->
   <include file="$(find waypoint_planner)/launch/astar_avoid.launch" />
   <include file="$(find waypoint_planner)/launch/velocity_set.launch" />
+
+  <!-- Autoware Plugin -->
+  <include file="$(find autoware_plugin)/launch/autoware_plugin.launch" />
 
   <!-- Route Generator -->
   <include file="$(find route_generator)/launch/route_generator.launch" />

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -96,6 +96,9 @@
 
   <!-- Voxel Grid Filter -->
   <group>
+  <node pkg="rostopic" type="rostopic" name="config_voxel_grid_filter_rostopic"
+	args="pub -l config/voxel_grid_filter autoware_config_msgs/ConfigVoxelGridFilter '{voxel_leaf_size: 4.0, measurement_range: 100.0}'"
+  />
     <remap from="/points_raw" to="ray_ground_filter/points_no_ground"/>
     <include file="$(find points_downsampler)/launch/points_downsample_remappable.launch">
       <arg name="node_name" value="voxel_grid_filter" />

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -94,7 +94,7 @@
   <!-- Voxel Grid Filter -->
   <group>
     <remap from="/points_raw" to="ray_ground_filter/points_no_ground"/>
-    <include file="$(find points_downsampler)/launch/points_downsample.launch">
+    <include file="$(find points_downsampler)/launch/points_downsample_remappable.launch">
       <arg name="node_name" value="voxel_grid_filter" />
     </include>
   </group>

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -22,6 +22,8 @@
   <arg name="INTR_NS" default="hardware_interface" doc="Namespace of nodes hardware interface stack"/>
   <arg name="area" default="5x5" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>
   <arg name="arealist_path" default="arealist.txt" doc="Path to the arealist.txt file which contains the paths and dimensions of each map cell to load"/>
+  <arg name="load_type" default="noupdate" doc="Enum of the map loading approach to use. Can be 'download', 'noupdate', or 'arealist'"/> 
+  <arg name="single_pcd_path" default="pcd_map.pcd" doc="Path to the map pcd file if using the noupdate load type"/>
   
   <!-- Remap any absolute topics to be relative -->
   <remap from="/vehicle/odom" to="vehicle/odom"/>
@@ -57,9 +59,10 @@
   <!-- Localization Package -->
   <!-- Point Cloud Map TODO file location and parameter loading process -->
   <include file="$(find map_file)/launch/map_loader.launch">
-    <arg name="load_type" value="arealist" />
-    <arg name="area" value="$(arg area)" />
-    <arg name="arealist_path" value="$(arg arealist_path)" />
+   <arg name="load_type" value="$(arg load_type)"/>
+   <arg name="single_pcd_path" value="$(arg single_pcd_path)"/>
+   <arg name="area" value="$(arg area)"/>
+   <arg name="arealist_path" value="$(arg arealist_path)"/>
   </include>
 
   <!-- NDT Matching-->

--- a/carmajava/launch/ui.launch
+++ b/carmajava/launch/ui.launch
@@ -48,7 +48,7 @@
   <remap from="bsm" to="$(arg MSG_NS)/incoming_bsm"/>
 
   <remap from="nav_sat_fix" to="$(arg INTR_NS)/gnss/nav_sat_fix"/>
-  <remap from="velocity" to="$(arg INTR_NS)/gnss/velocity"/>
+  <remap from="velocity" to="$(arg INTR_NS)/vehicle/twist"/>
   <remap from="driver_discovery" to="$(arg INTR_NS)/driver_discovery"/>
   <remap from="get_drivers_with_capabilities" to="$(arg INTR_NS)/get_drivers_with_capabilities"/>
   <remap from="controller/robotic_status" to="$(arg INTR_NS)/controller/robot_status"/>

--- a/engineering_tools/carma_default.rviz
+++ b/engineering_tools/carma_default.rviz
@@ -1,0 +1,798 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /TF1
+        - /Points Map1
+        - /Camera1/Visibility1
+        - /Points Raw1
+        - /Points Raw1/Status1
+        - /Vehicle Model1/Status1
+        - /Local Waypoints1
+        - /Local Waypoints1/Status1
+        - /Global Waypoints1
+        - /Vector Map CenterLines1/Namespaces1
+        - /Global Path1/Namespaces1
+        - /Local Rollouts1/Namespaces1
+        - /GlobalPathAnimation1/Status1
+        - /Pose1
+      Splitter Ratio: 0.296568632
+    Tree Height: 524
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: Points Map
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: false
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base_link:
+          Value: true
+        earth:
+          Value: true
+        host_vehicle:
+          Value: true
+        map:
+          Value: true
+        mobileye:
+          Value: true
+        ned_heading:
+          Value: true
+        novatel_gnss:
+          Value: true
+        novatel_imu:
+          Value: true
+        radar_fc:
+          Value: true
+        radar_fl:
+          Value: true
+        radar_fr:
+          Value: true
+        radar_rl:
+          Value: true
+        radar_rr:
+          Value: true
+        vehicle_front:
+          Value: true
+        velodyne:
+          Value: true
+      Marker Scale: 5
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        earth:
+          map:
+            base_link:
+              host_vehicle:
+                {}
+              mobileye:
+                {}
+              novatel_gnss:
+                ned_heading:
+                  {}
+              novatel_imu:
+                {}
+              radar_fc:
+                {}
+              radar_fl:
+                {}
+              radar_fr:
+                {}
+              radar_rl:
+                {}
+              radar_rr:
+                {}
+              vehicle_front:
+                {}
+              velodyne:
+                {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 0.0500000007
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Points Map
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 2
+      Size (m): 0.00999999978
+      Style: Points
+      Topic: /localization/points_map
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /vector_map
+      Name: Vector Map
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Camera
+      Enabled: false
+      Image Rendering: overlay
+      Image Topic: /image_raw
+      Name: Camera
+      Overlay Alpha: 0.400000006
+      Queue Size: 10
+      Transport Hint: raw
+      Unreliable: false
+      Value: false
+      Visibility:
+        "": true
+        A* Sim Obstacle: true
+        Behavior State: true
+        Control Pose: true
+        Current Pose: true
+        Detection Range: true
+        ERROR: true
+        FATAL: true
+        Global Path: true
+        Global Waypoints: true
+        GlobalPathAnimation: true
+        Grid: true
+        Image: true
+        Local Rollouts: true
+        Local Waypoints: true
+        MarkerArray: true
+        Next Waypoint Mark: true
+        OK: true
+        Occupancy Grid Map: true
+        OverlayImage: true
+        OverlayText: true
+        PP Trajectory Mark: true
+        Points Cluster: true
+        Points Map: true
+        Points Raw: true
+        Pose: true
+        Safety Box: true
+        Simulated Obstacle: true
+        Stixel: true
+        TF: false
+        Tracked Contours: true
+        Value: true
+        Vector Map: true
+        Vector Map CenterLines: true
+        Vehicle Model: true
+        Velocity (km/h): true
+        Vscan Points: true
+        WARN: true
+        Waypoint Guide: true
+      Zoom Factor: 1
+    - Alpha: 0.600000024
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 5.33789921
+        Min Value: -15.091835
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 252
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Points Raw
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.00999999978
+      Style: Points
+      Topic: /hardware_interface/lidar/points_raw
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 0.5
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 0
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 255
+      Min Color: 0; 0; 0
+      Min Intensity: 255
+      Name: Vscan Points
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.00999999978
+      Style: Points
+      Topic: /vscan_points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.100000001
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: false
+      Head Length: 2
+      Head Radius: 2
+      Name: Control Pose
+      Shaft Length: 2
+      Shaft Radius: 1
+      Shape: Arrow
+      Topic: /control_pose
+      Unreliable: false
+      Value: false
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.100000001
+      Class: rviz/Pose
+      Color: 255; 170; 255
+      Enabled: false
+      Head Length: 2
+      Head Radius: 2
+      Name: Current Pose
+      Shaft Length: 2
+      Shaft Radius: 1
+      Shape: Arrow
+      Topic: /ndt_pose
+      Unreliable: false
+      Value: false
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /detection_range
+      Name: Detection Range
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /next_target_mark
+      Name: Next Waypoint Mark
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /trajectory_circle_mark
+      Name: PP Trajectory Mark
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: false
+      Marker Topic: /vscan_linelist
+      Name: Stixel
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: false
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled:
+          {}
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        host_vehicle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mobileye:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        ned_heading:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        novatel_gnss:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        novatel_imu:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        radar_fc:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        radar_fl:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        radar_fr:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        radar_rl:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        radar_rr:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        vehicle_front:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        velodyne:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: Vehicle Model
+      Robot Description: /transform/robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Points Cluster
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 5
+      Size (m): 0.00999999978
+      Style: Points
+      Topic: /points_cluster
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /guidance/local_waypoints_mark
+      Name: Local Waypoints
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /guidance/global_waypoints_mark
+      Name: Global Waypoints
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /waypoint_guide
+      Name: Waypoint Guide
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /astar_sim_obstacle
+      Name: A* Sim Obstacle
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Alpha: 0.699999988
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: true
+      Enabled: true
+      Name: Occupancy Grid Map
+      Topic: /grid_map_filter_visualization/distance_transform
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /vector_map_center_lines_rviz
+      Name: Vector Map CenterLines
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /global_waypoints_rviz
+      Name: Global Path
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /local_trajectories
+      Name: Local Rollouts
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /detected_polygons
+      Name: Tracked Contours
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /behavior_state
+      Name: Behavior State
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /AnimateGlobalPlan
+      Name: GlobalPathAnimation
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /safety_border
+      Name: Safety Box
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: jsk_rviz_plugin/BoundingBoxArray
+      Enabled: true
+      Name: Simulated Obstacle
+      Topic: /dp_planner_tracked_boxes
+      Unreliable: false
+      Value: true
+      alpha: 0.800000012
+      color: 25; 255; 0
+      coloring: Value
+      line width: 0.00999999978
+      only edge: false
+      show coords: false
+    - Buffer length: 100
+      Class: jsk_rviz_plugin/Plotter2D
+      Enabled: true
+      Name: Velocity (km/h)
+      Show Value: true
+      Topic: /linear_velocity_viz
+      Value: true
+      auto color change: false
+      auto scale: true
+      background color: 0; 0; 0
+      backround alpha: 0
+      border: true
+      foreground alpha: 0.699999988
+      foreground color: 85; 255; 0
+      height: 80
+      left: 40
+      linewidth: 1
+      max color: 255; 0; 0
+      max value: 1
+      min value: -1
+      show caption: true
+      text size: 8
+      top: 30
+      update interval: 0.0399999991
+      width: 80
+    - Align Bottom: false
+      Background Alpha: 0.800000012
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.800000012
+      Foreground Color: 25; 255; 240
+      Name: OverlayText
+      Overtake Color Properties: false
+      Overtake Position Properties: false
+      Topic: /ndt_monitor/ndt_info_text
+      Value: true
+      font: DejaVu Sans Mono
+      height: 128
+      left: 0
+      line width: 2
+      text size: 12
+      top: 0
+      width: 128
+    - Class: rviz/Image
+      Enabled: false
+      Image Topic: /image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: false
+    - Class: jsk_rviz_plugin/OverlayImage
+      Enabled: false
+      Name: OverlayImage
+      Topic: /image_raw
+      Value: false
+      alpha: 0.800000012
+      height: 128
+      keep aspect ratio: true
+      left: 128
+      top: 128
+      width: 640
+    - Align Bottom: false
+      Background Alpha: 0.800000012
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.800000012
+      Foreground Color: 25; 255; 240
+      Name: OK
+      Overtake Color Properties: false
+      Overtake Position Properties: false
+      Topic: /health_aggregator/ok_text
+      Value: true
+      font: DejaVu Sans Mono
+      height: 128
+      left: 0
+      line width: 2
+      text size: 12
+      top: 0
+      width: 128
+    - Align Bottom: false
+      Background Alpha: 0.800000012
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.800000012
+      Foreground Color: 25; 255; 240
+      Name: WARN
+      Overtake Color Properties: false
+      Overtake Position Properties: false
+      Topic: /health_aggregator/warn_text
+      Value: true
+      font: DejaVu Sans Mono
+      height: 128
+      left: 0
+      line width: 2
+      text size: 12
+      top: 0
+      width: 128
+    - Align Bottom: false
+      Background Alpha: 0.800000012
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.800000012
+      Foreground Color: 25; 255; 240
+      Name: ERROR
+      Overtake Color Properties: false
+      Overtake Position Properties: false
+      Topic: /health_aggregator/error_text
+      Value: true
+      font: DejaVu Sans Mono
+      height: 128
+      left: 0
+      line width: 2
+      text size: 12
+      top: 0
+      width: 128
+    - Align Bottom: false
+      Background Alpha: 0.800000012
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.800000012
+      Foreground Color: 25; 255; 240
+      Name: FATAL
+      Overtake Color Properties: false
+      Overtake Position Properties: false
+      Topic: /health_aggregator/fatal_text
+      Value: true
+      font: DejaVu Sans Mono
+      height: 128
+      left: 0
+      line width: 2
+      text size: 12
+      top: 0
+      width: 128
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /waypoint_saver_marker
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /detection/lidar_detector/objects_markers
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Alpha: 1
+      Axes Length: 10
+      Axes Radius: 1
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.300000012
+      Head Radius: 0.100000001
+      Name: Pose
+      Shaft Length: 1
+      Shaft Radius: 0.0500000007
+      Shape: Axes
+      Topic: /localization/gnss_pose
+      Unreliable: false
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /guidance/global_waypoints_mark
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Angle: 0.75
+      Class: rviz/TopDownOrtho
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Scale: 12.6148386
+      Target Frame: base_link
+      Value: TopDownOrtho (rviz)
+      X: 146.005035
+      Y: -73.0888138
+    Saved: ~
+Window Geometry:
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 776
+  Hide Left Dock: false
+  Hide Right Dock: true
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001a60000024dfc0200000010fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afc000000280000024d000000d700fffffffa000000020100000003fb0000000a0049006d0061006700650000000000ffffffff0000005c00fffffffb0000000c00430061006d0065007200610000000000ffffffff0000006700fffffffb000000100044006900730070006c0061007900730100000000000001360000016a00fffffffb0000000a0049006d006100670065010000028e000000d20000000000000000fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000120049006d006100670065005f0072006100770000000000ffffffff0000000000000000fb0000000c00430061006d006500720061000000024e000001710000000000000000fb000000120049006d00610067006500200052006100770100000421000000160000000000000000fb0000000a0049006d00610067006501000002f4000000cb0000000000000000fb0000000a0049006d006100670065010000056c0000026c0000000000000000fb0000002000430061006d006500720061002000500061007300730065006e0067006500720000000028000003d50000000000000000fb0000001a00430061006d00650072006100200044007200690076006500720000000403000003d50000000000000000000000010000010f0000024dfc0200000003fb0000000a0056006900650077007300000000280000024d000000ad00fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b20000000000000000000000020000073f000000a8fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004bf0000006ffc0100000002fb0000000800540069006d00650100000000000004bf0000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000003130000024d00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1215
+  X: 65
+  Y: 24

--- a/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper_worker.hpp
+++ b/pure_pursuit_wrapper/include/pure_pursuit_wrapper/pure_pursuit_wrapper_worker.hpp
@@ -25,6 +25,6 @@ namespace pure_pursuit_wrapper {
 class PurePursuitWrapperWorker {
     public:
         // Convert TrajectoryPlanPoint to Waypoint. This is used by TrajectoryPlanHandler.
-        autoware_msgs::Waypoint TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp);
+        autoware_msgs::Waypoint TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp, cav_msgs::TrajectoryPlanPoint tpp2);
 };
 }

--- a/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
+++ b/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+    <remap from="final_waypoints" to="carma_final_waypoints"/>
     <!-- Pure Pursuit Node -->
     <include file="$(find waypoint_follower)/launch/pure_pursuit.launch">
         <arg name="is_linear_interpolation" value="True"/>

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -59,7 +59,7 @@ void PurePursuitWrapper::TrajectoryPlanPoseHandler(const geometry_msgs::PoseStam
       lane.header = tp->header;
       std::vector <autoware_msgs::Waypoint> waypoints;
       double current_time = ros::Time::now().toSec();
-      for(int i = 0; i < tp->trajectory_points.size() - 1; i++ ) {
+      for(int i = 1; i < tp->trajectory_points.size() - 1; i++ ) {
 
         cav_msgs::TrajectoryPlanPoint t1 = tp->trajectory_points[i];
         cav_msgs::TrajectoryPlanPoint t2 = tp->trajectory_points[i + 1];

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -59,8 +59,11 @@ void PurePursuitWrapper::TrajectoryPlanPoseHandler(const geometry_msgs::PoseStam
       lane.header = tp->header;
       std::vector <autoware_msgs::Waypoint> waypoints;
       double current_time = ros::Time::now().toSec();
-      for(cav_msgs::TrajectoryPlanPoint tpp : tp->trajectory_points) {
-        autoware_msgs::Waypoint waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, *pose,tpp);
+      for(int i = 0; i < tp->trajectory_points.size() - 1; i++ ) {
+
+        cav_msgs::TrajectoryPlanPoint t1 = tp->trajectory_points[i];
+        cav_msgs::TrajectoryPlanPoint t2 = tp->trajectory_points[i + 1];
+        autoware_msgs::Waypoint waypoint = ppww.TrajectoryPlanPointToWaypointConverter(current_time, *pose,t1, t2);
         waypoints.push_back(waypoint);
       }
 

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -40,12 +40,12 @@ void PurePursuitWrapper::Initialize() {
   system_alert_pub_ = nh_.advertise<cav_msgs::SystemAlert>("system_alert", 10, true);
 
   // Pose Subscriber
-  pose_sub.subscribe(nh_, "/current_pose", 1);
+  pose_sub.subscribe(nh_, "current_pose", 1);
   // Trajectory Plan Subscriber
   trajectory_plan_sub.subscribe(nh_, "trajectory_plan", 1);
 
   // WayPoints Publisher
-  way_points_pub_ = nh_.advertise<autoware_msgs::Lane>("/final_waypoints", 10, true);
+  way_points_pub_ = nh_.advertise<autoware_msgs::Lane>("final_waypoints", 10, true);
 }
 
 bool PurePursuitWrapper::ReadParameters() {

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper.cpp
@@ -59,7 +59,7 @@ void PurePursuitWrapper::TrajectoryPlanPoseHandler(const geometry_msgs::PoseStam
       lane.header = tp->header;
       std::vector <autoware_msgs::Waypoint> waypoints;
       double current_time = ros::Time::now().toSec();
-      for(int i = 1; i < tp->trajectory_points.size() - 1; i++ ) {
+      for(int i = 0; i < tp->trajectory_points.size() - 1; i++ ) {
 
         cav_msgs::TrajectoryPlanPoint t1 = tp->trajectory_points[i];
         cav_msgs::TrajectoryPlanPoint t2 = tp->trajectory_points[i + 1];

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_node.cpp
@@ -29,7 +29,8 @@ int main(int argc, char** argv) {
 
   pure_pursuit_wrapper::PurePursuitWrapper PurePursuitWrapper(nh);
 
-  message_filters::Synchronizer<pure_pursuit_wrapper::PurePursuitWrapper::SyncPolicy> sync(pure_pursuit_wrapper::PurePursuitWrapper::SyncPolicy(10), PurePursuitWrapper.pose_sub, PurePursuitWrapper.trajectory_plan_sub);
+  // Approximate time of 100ms used because NDT outputs at 10Hz
+  message_filters::Synchronizer<pure_pursuit_wrapper::PurePursuitWrapper::SyncPolicy> sync(pure_pursuit_wrapper::PurePursuitWrapper::SyncPolicy(100), PurePursuitWrapper.pose_sub, PurePursuitWrapper.trajectory_plan_sub);
   sync.registerCallback(boost::bind(&pure_pursuit_wrapper::PurePursuitWrapper::TrajectoryPlanPoseHandler, &PurePursuitWrapper, _1, _2));
 
   while (ros::ok() && !PurePursuitWrapper.shutting_down_) {

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -24,15 +24,16 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
 
   waypoint.pose.pose.position.x = tpp.x;
   waypoint.pose.pose.position.y = tpp.y;
+  double delta_x = tpp.x - pose.pose.position.x;
+  double delta_y = tpp.y - pose.pose.position.y;
+  double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
   double delta_t_secound = (tpp.target_time / 1e9) - current_time;
 
   if(delta_t_secound != 0) {
-    waypoint.twist.twist.linear.x = 3.6 * (tpp.x - pose.pose.position.x) / delta_t_secound;
-    waypoint.twist.twist.linear.y = 3.6 * (tpp.y - pose.pose.position.y) / delta_t_secound;
+    waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_secound);
   }
   else {
     waypoint.twist.twist.linear.x = 0;
-    waypoint.twist.twist.linear.y = 0;
   }
 
   return waypoint;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -27,7 +27,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
   double delta_x = tpp.x - pose.pose.position.x;
   double delta_y = tpp.y - pose.pose.position.y;
   double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
-  double delta_t_secound = (tpp.target_time / 1e9) - current_time;
+  double delta_t_secound = abs((tpp.target_time / 1e9) - current_time);
 
   if(delta_t_secound != 0) {
     waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_secound);

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -27,7 +27,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
   double delta_x = tpp.x - pose.pose.position.x;
   double delta_y = tpp.y - pose.pose.position.y;
   double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
-  double delta_t_second = abs((double)(tpp.target_time / 1e9) - (double)current_time);
+  double delta_t_second = abs(((double)tpp.target_time / 1e9) - (double)current_time);
 
   if(delta_t_secound != 0) {
     waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_second);

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -27,10 +27,10 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
   double delta_x = tpp.x - pose.pose.position.x;
   double delta_y = tpp.y - pose.pose.position.y;
   double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
-  double delta_t_secound = abs((tpp.target_time / 1e9) - current_time);
+  double delta_t_second = abs((double)(tpp.target_time / 1e9) - (double)current_time);
 
   if(delta_t_secound != 0) {
-    waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_secound);
+    waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_second);
   }
   else {
     waypoint.twist.twist.linear.x = 0;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -30,7 +30,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
   double delta_t_second = fabs(((double)tpp.target_time / 1e9) - (double)current_time);
 
   if(delta_t_second != 0) {
-    waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_second);
+    waypoint.twist.twist.linear.x = delta_pos / delta_t_second;
   }
   else {
     waypoint.twist.twist.linear.x = 0;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -18,16 +18,17 @@
 
 namespace pure_pursuit_wrapper {
 
-autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp) {
+autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointConverter(double current_time, geometry_msgs::PoseStamped pose, cav_msgs::TrajectoryPlanPoint tpp, cav_msgs::TrajectoryPlanPoint tpp2) {
 
   autoware_msgs::Waypoint waypoint;
 
+
   waypoint.pose.pose.position.x = tpp.x;
   waypoint.pose.pose.position.y = tpp.y;
-  double delta_x = tpp.x - pose.pose.position.x;
-  double delta_y = tpp.y - pose.pose.position.y;
+  double delta_x = tpp.x - tpp2.x;
+  double delta_y = tpp.y - tpp2.y;
   double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
-  double delta_t_second = fabs(((double)tpp.target_time / 1e9) - (double)current_time);
+  double delta_t_second = fabs((double)(tpp.target_time - tpp2.target_time) / 1e9);
 
   if(delta_t_second != 0) {
     waypoint.twist.twist.linear.x = delta_pos / delta_t_second;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -24,7 +24,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
 
   waypoint.pose.pose.position.x = tpp.x;
   waypoint.pose.pose.position.y = tpp.y;
-  double delta_t_secound = (tpp.target_time / 1000.0) - current_time;
+  double delta_t_secound = (tpp.target_time / 1e9) - current_time;
 
   if(delta_t_secound != 0) {
     waypoint.twist.twist.linear.x = 3.6 * (tpp.x - pose.pose.position.x) / delta_t_secound;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -28,7 +28,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
   double delta_x = tpp.x - tpp2.x;
   double delta_y = tpp.y - tpp2.y;
   double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
-  double delta_t_second = fabs((double)(tpp.target_time - tpp2.target_time) / 1e9);
+  double delta_t_second = (double)abs(tpp2.target_time - tpp.target_time) / 1e9;
 
   if(delta_t_second != 0) {
     waypoint.twist.twist.linear.x = delta_pos / delta_t_second;

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -27,7 +27,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
   double delta_x = tpp.x - pose.pose.position.x;
   double delta_y = tpp.y - pose.pose.position.y;
   double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
-  double delta_t_second = abs(((double)tpp.target_time / 1e9) - (double)current_time);
+  double delta_t_second = fabs(((double)tpp.target_time / 1e9) - (double)current_time);
 
   if(delta_t_second != 0) {
     waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_second);

--- a/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
+++ b/pure_pursuit_wrapper/src/pure_pursuit_wrapper_worker.cpp
@@ -29,7 +29,7 @@ autoware_msgs::Waypoint PurePursuitWrapperWorker::TrajectoryPlanPointToWaypointC
   double delta_pos = sqrt(delta_x * delta_x + delta_y * delta_y);
   double delta_t_second = abs(((double)tpp.target_time / 1e9) - (double)current_time);
 
-  if(delta_t_secound != 0) {
+  if(delta_t_second != 0) {
     waypoint.twist.twist.linear.x = 3.6 * (delta_pos / delta_t_second);
   }
   else {

--- a/trajectory_executor/config/roscpp_log.config
+++ b/trajectory_executor/config/roscpp_log.config
@@ -1,2 +1,3 @@
 # Set the default ros output to warning and higher
-log4j.logger.ros=INFO
+log4j.logger.ros=WARN
+log4j.logger.ros.trajectory_executor=DEBUG

--- a/trajectory_executor/config/trajectory_executor.yaml
+++ b/trajectory_executor/config/trajectory_executor.yaml
@@ -29,4 +29,4 @@ default_control_plugin: pure_pursuit
 
 # String: Full path to default control plugin's trajectory input topic
 # Units: N/a
-default_control_plugin_topic: /carma/guidance/control_plugins/pure_pursuit/trajectory
+default_control_plugin_topic: /guidance/pure_pursuit/trajectory

--- a/trajectory_executor/include/trajectory_executor/trajectory_executor.hpp
+++ b/trajectory_executor/include/trajectory_executor/trajectory_executor.hpp
@@ -36,7 +36,7 @@ namespace trajectory_executor {
      * \param plan The plan to modify
      * \return A new message with the copied contents minus the first point
      */
-    cav_msgs::TrajectoryPlan trimFirstPoint(const cav_msgs::TrajectoryPlan &plan);
+    cav_msgs::TrajectoryPlan trimPastPoints(const cav_msgs::TrajectoryPlan &plan);
 
     /**
      * Trajectory Executor package primary worker class

--- a/trajectory_executor/src/test/test_utils.h
+++ b/trajectory_executor/src/test/test_utils.h
@@ -31,10 +31,10 @@ class TrajectoryExecutorTestSuite : public ::testing::Test
     public:
         TrajectoryExecutorTestSuite() {
             _nh = ros::NodeHandle();
-            traj_pub = _nh.advertise<cav_msgs::TrajectoryPlan>("/trajectory_executor_node/trajectory", 5);
-            traj_sub = _nh.subscribe<cav_msgs::TrajectoryPlan>("/carma/guidance/control_plugins/pure_pursuit/trajectory", 100, 
+            traj_pub = _nh.advertise<cav_msgs::TrajectoryPlan>("trajectory", 5);
+            traj_sub = _nh.subscribe<cav_msgs::TrajectoryPlan>("guidance/pure_pursuit/trajectory", 100, 
             &TrajectoryExecutorTestSuite::trajEmitCallback, this);
-            sys_alert_sub = _nh.subscribe<cav_msgs::SystemAlert>("/system_alert", 100, 
+            sys_alert_sub = _nh.subscribe<cav_msgs::SystemAlert>("system_alert", 100, 
             &TrajectoryExecutorTestSuite::sysAlertCallback, this);
         }
         ros::NodeHandle _nh;
@@ -48,7 +48,7 @@ class TrajectoryExecutorTestSuite : public ::testing::Test
 
         void trajEmitCallback(cav_msgs::TrajectoryPlan msg) {
             msg_count++;
-            if (msg.trajectory_points.size() < last_points && shrinking) {
+            if (msg.trajectory_points.size() <= last_points && shrinking) {
                 last_points = msg.trajectory_points.size();
             } else {
                 shrinking = false;
@@ -94,12 +94,13 @@ cav_msgs::TrajectoryPlan buildSampleTraj() {
     plan.header.stamp = ros::Time::now();
     plan.trajectory_id = "TEST TRAJECTORY 1";
 
+    uint64_t cur_time_nanos = ros::Time::now().toNSec();
     for (int i = 0; i < 10; i++) {
         cav_msgs::TrajectoryPlanPoint p;
         p.controller_plugin_name = "pure_pursuit";
         p.lane_id = "0";
         p.planner_plugin_name = "cruising";
-        p.target_time = i * 0.1;
+        p.target_time = cur_time_nanos + i * 130000000;
         p.x = 10 * i;
         p.y = 10 * i;
         plan.trajectory_points.push_back(p);

--- a/trajectory_executor/src/test/trajectory_executor_test_1.cpp
+++ b/trajectory_executor/src/test/trajectory_executor_test_1.cpp
@@ -38,7 +38,7 @@ TEST_F(TrajectoryExecutorTestSuite, test_emit_traj) {
 
     traj_pub.publish(plan);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
     ASSERT_GT(msg_count, 0) << "Failed to receive trajectory execution message from TrajectoryExecutor node.";
 } 
 

--- a/trajectory_executor/src/test/trajectory_executor_test_2.cpp
+++ b/trajectory_executor/src/test/trajectory_executor_test_2.cpp
@@ -28,7 +28,7 @@ TEST_F(TrajectoryExecutorTestSuite, test_emit_multiple) {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
-    ASSERT_EQ(10, msg_count) << "Failed to receive whole trajectory from TrajectoryExecutor node.";
+    ASSERT_LE(10, msg_count) << "Failed to receive whole trajectory from TrajectoryExecutor node.";
     ASSERT_TRUE(shrinking) << "Output trajectory plans were not shrunk each time step as expected.";
 }
 

--- a/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
+++ b/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
@@ -141,7 +141,7 @@ namespace trajectory_executor
         ROS_DEBUG_STREAM("Initalized params with default_spin_rate " << _default_spin_rate 
             << " and trajectory_publish_rate " << _min_traj_publish_tickrate_hz);
 
-        this->_plan_sub = this->_private_nh->subscribe<cav_msgs::TrajectoryPlan>("trajectory", 5, &TrajectoryExecutor::onNewTrajectoryPlan, this);
+        this->_plan_sub = this->_public_nh->subscribe<cav_msgs::TrajectoryPlan>("trajectory", 5, &TrajectoryExecutor::onNewTrajectoryPlan, this);
         this->_cur_traj = std::unique_ptr<cav_msgs::TrajectoryPlan>();
         ROS_DEBUG("Subscribed to inbound trajectory plans.");
 

--- a/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
+++ b/trajectory_executor/src/trajectory_executor/trajectory_executor.cpp
@@ -64,6 +64,7 @@ namespace trajectory_executor
         ROS_DEBUG_STREAM("New plan contains " << msg.trajectory_points.size() << " points");
 
         _cur_traj = std::unique_ptr<cav_msgs::TrajectoryPlan>(new cav_msgs::TrajectoryPlan(msg));
+        _timesteps_since_last_traj = 0;
         ROS_DEBUG_STREAM("Successfully swapped trajectories!");
     }
 

--- a/trajectory_executor/test/trajectory_executor_1.test
+++ b/trajectory_executor/test/trajectory_executor_1.test
@@ -15,7 +15,6 @@
   the License.
 -->
 <launch>
-    <env name="ROSCONSOLE_CONFIG_FILE" value="$(find trajectory_executor)/config/roscpp_log.config"/>
     <node pkg="trajectory_executor" type="trajectory_executor_node" name="trajectory_executor_node">
         <rosparam command="load" file="$(find trajectory_executor)/config/trajectory_executor.yaml" />
     </node>

--- a/trajectory_executor/test/trajectory_executor_1.test
+++ b/trajectory_executor/test/trajectory_executor_1.test
@@ -19,5 +19,6 @@
     <node pkg="trajectory_executor" type="trajectory_executor_node" name="trajectory_executor_node">
         <rosparam command="load" file="$(find trajectory_executor)/config/trajectory_executor.yaml" />
     </node>
+
     <test test-name="trajectory_executor_test_1" pkg="trajectory_executor" type="trajectory_executor_test_1" />
 </launch>

--- a/trajectory_executor/test/trajectory_executor_2.test
+++ b/trajectory_executor/test/trajectory_executor_2.test
@@ -15,7 +15,6 @@
   the License.
 -->
 <launch>
-    <env name="ROSCONSOLE_CONFIG_FILE" value="$(find trajectory_executor)/config/roscpp_log.config"/>
     <node pkg="trajectory_executor" type="trajectory_executor_node" name="trajectory_executor_node">
         <rosparam command="load" file="$(find trajectory_executor)/config/trajectory_executor.yaml" />
     </node>

--- a/trajectory_executor/test/trajectory_executor_3.test
+++ b/trajectory_executor/test/trajectory_executor_3.test
@@ -15,7 +15,6 @@
   the License.
 -->
 <launch>
-    <env name="ROSCONSOLE_CONFIG_FILE" value="$(find trajectory_executor)/config/roscpp_log.config"/>
     <node pkg="trajectory_executor" type="trajectory_executor_node" name="trajectory_executor_node">
         <rosparam command="load" file="$(find trajectory_executor)/config/trajectory_executor.yaml" />
     </node>


### PR DESCRIPTION
# PR Details

## Description
Fixes several issues encountered during integration testing for CARMA3 beta release: 

* Fix topic mappings and namespaces in Guidance
* Fix lack of return statement error in Autoware Plugin and CARMANodeHandle
* Fix timestamp calculation on trajectory points in AutowarePlugin
* Change Pure Pursuit Wrapper to use ns-resolution timestamps
* Change Pure Pursuit Wrapper to use speed instead of velocity
* Fix negative timestamp calculation issue in Pure Pursuit Wrapper
* Change Pure Pursuit Wrapper to work in m/s instead of kph
* Rework vehicle motion assumptions in Pure Pursuit Wrapper to match Autoware Plugin
* Correct map file loading arguments
* Remove trajectory evening function in Autoware Plugin to avoid cases where interpolation over a trajectory inflection point causes erroneous speed derivation to result in random braking
* Change trajectory executor trajectory point expiry to process nodes based on time elapsed rather than index
* Remap current speed topic correctly for usage with the Autoware Plugin UI Widget
* Add CARMA default Rviz configuration to repository

## How Has This Been Tested?

This has been tested on-vehicle, though results are preliminary as further integration testing is required.

## Types of changes
- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Related Issue
Closes #289 
Closes #290 
Closes #291 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
