### PR TITLE
BSM Generator

### DIFF
--- a/bsm_generator/CMakeLists.txt
+++ b/bsm_generator/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(catkin REQUIRED COMPONENTS
   pacmod_msgs
   j2735_msgs
   novatel_gps_msgs
+  sensor_fusion
 )
 
 ## System dependencies are found with CMake's conventions
@@ -42,7 +43,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 
 catkin_package(
   CATKIN_DEPENDS roscpp std_msgs cav_msgs carma_utils automotive_platform_msgs
-                 geometry_msgs pacmod_msgs j2735_msgs novatel_gps_msgs
+                 geometry_msgs pacmod_msgs j2735_msgs novatel_gps_msgs sensor_fusion
 )
 
 ###########

--- a/bsm_generator/CMakeLists.txt
+++ b/bsm_generator/CMakeLists.txt
@@ -1,0 +1,96 @@
+#
+# Copyright (C) 2018-2019 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+cmake_minimum_required(VERSION 2.8.3)
+project(bsm_generator)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+  cav_msgs
+  carma_utils
+  automotive_platform_msgs
+  geometry_msgs
+  pacmod_msgs
+  j2735_msgs
+  novatel_gps_msgs
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system)
+
+###################################
+## catkin specific configuration ##
+###################################
+
+catkin_package(
+  CATKIN_DEPENDS roscpp std_msgs cav_msgs carma_utils automotive_platform_msgs
+                 geometry_msgs pacmod_msgs j2735_msgs novatel_gps_msgs
+)
+
+###########
+## Build ##
+###########
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  include
+)
+
+file(GLOB_RECURSE headers */*.hpp */*.h)
+
+add_executable( ${PROJECT_NAME}
+  ${headers}
+  src/bsm_generator.cpp
+  src/bsm_generator_worker.cpp
+  src/main.cpp)
+add_library(bsm_generator_worker_library src/bsm_generator_worker.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+add_dependencies(bsm_generator_worker_library ${catkin_EXPORTED_TARGETS})
+
+#############
+## Install ##
+#############
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.hpp"
+  PATTERN ".svn" EXCLUDE
+)
+
+## Install C++
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Install Other Resources
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+catkin_add_gmock(${PROJECT_NAME}-test test/test_bsm_generator_worker.cpp)
+target_link_libraries(${PROJECT_NAME}-test bsm_generator_worker_library ${catkin_LIBRARIES})

--- a/bsm_generator/config/parameters.yaml
+++ b/bsm_generator/config/parameters.yaml
@@ -1,0 +1,2 @@
+# The desired frequency for BSM generation
+bsm_generation_frequency: 10.0

--- a/bsm_generator/include/bsm_generator.h
+++ b/bsm_generator/include/bsm_generator.h
@@ -16,6 +16,7 @@
  * the License.
  */
 
+#include <tf2_ros/transform_listener.h>
 #include <boost/shared_ptr.hpp>
 #include <carma_utils/CARMAUtils.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -24,6 +25,7 @@
 #include <pacmod_msgs/YawRateRpt.h>
 #include <j2735_msgs/TransmissionState.h>
 #include <std_msgs/Float64.h>
+#include <wgs84_utils/wgs84_utils.h>
 #include <novatel_gps_msgs/NovatelDualAntennaHeading.h>
 #include "bsm_generator_worker.h"
 
@@ -45,6 +47,7 @@ namespace bsm_generator
         // node handles
         std::shared_ptr<ros::CARMANodeHandle> nh_, pnh_;
 
+        // worker class
         BSMGeneratorWorker worker;
 
         // publisher for generated BSMs
@@ -56,9 +59,13 @@ namespace bsm_generator
         ros::Subscriber yaw_sub_;
         ros::Subscriber gear_sub_;
         ros::Subscriber speed_sub_;
-        ros::Subscriber heading_sub_;
         ros::Subscriber steer_wheel_angle_sub_;
         ros::Subscriber brake_sub_;
+        ros::Subscriber heading_sub_;
+
+        // TF listenser
+        tf2_ros::Buffer tf2_buffer_;
+        std::unique_ptr<tf2_ros::TransformListener> tf2_listener_;
 
         // frequency for bsm generation
         double bsm_generation_frequency_;
@@ -84,9 +91,9 @@ namespace bsm_generator
         void yawCallback(const pacmod_msgs::YawRateRptConstPtr& msg);
         void gearCallback(const j2735_msgs::TransmissionStateConstPtr& msg);
         void speedCallback(const std_msgs::Float64ConstPtr& msg);
-        void headingCallback(const novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr& msg);
         void steerWheelAngleCallback(const std_msgs::Float64ConstPtr& msg);
         void brakeCallback(const std_msgs::Float64ConstPtr& msg);
+        void headingCallback(const novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr& msg);
 
         // callback for the timer
         void generateBSM(const ros::TimerEvent& event);

--- a/bsm_generator/include/bsm_generator.h
+++ b/bsm_generator/include/bsm_generator.h
@@ -63,6 +63,9 @@ namespace bsm_generator
         // frequency for bsm generation
         double bsm_generation_frequency_;
 
+        // size of the vehicle
+        double vehicle_length_, vehicle_width_;
+
         // timer to run the bsm generation task
         ros::Timer timer_;
 
@@ -87,7 +90,6 @@ namespace bsm_generator
 
         // callback for the timer
         void generateBSM(const ros::TimerEvent& event);
-
     };
 
 }

--- a/bsm_generator/include/bsm_generator.h
+++ b/bsm_generator/include/bsm_generator.h
@@ -1,0 +1,93 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <boost/shared_ptr.hpp>
+#include <carma_utils/CARMAUtils.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <cav_msgs/BSM.h>
+#include <automotive_platform_msgs/VelocityAccel.h>
+#include <pacmod_msgs/YawRateRpt.h>
+#include <j2735_msgs/TransmissionState.h>
+#include <std_msgs/Float64.h>
+#include <novatel_gps_msgs/NovatelDualAntennaHeading.h>
+#include "bsm_generator_worker.h"
+
+namespace bsm_generator
+{
+
+    class BSMGenerator
+    {
+
+    public:
+
+        BSMGenerator();
+
+        // general starting point of this node
+        void run();
+
+    private:
+
+        // node handles
+        std::shared_ptr<ros::CARMANodeHandle> nh_, pnh_;
+
+        BSMGeneratorWorker worker;
+
+        // publisher for generated BSMs
+        ros::Publisher  bsm_pub_;
+
+        // subscribers for gathering data from the platform
+        ros::Subscriber pose_sub_;
+        ros::Subscriber accel_sub_;
+        ros::Subscriber yaw_sub_;
+        ros::Subscriber gear_sub_;
+        ros::Subscriber speed_sub_;
+        ros::Subscriber heading_sub_;
+        ros::Subscriber steer_wheel_angle_sub_;
+        ros::Subscriber brake_sub_;
+
+        // frequency for bsm generation
+        double bsm_generation_frequency_;
+
+        // timer to run the bsm generation task
+        ros::Timer timer_;
+
+        // the BSM object that all subscribers make updates to
+        cav_msgs::BSM bsm_;
+
+        // initialize this node
+        void initialize();
+
+        // fill some default data in BSM
+        void initializeBSM();
+
+        // callbacks for the subscribers
+        void poseCallback(const geometry_msgs::PoseStampedConstPtr& msg);
+        void accelCallback(const automotive_platform_msgs::VelocityAccelConstPtr& msg);
+        void yawCallback(const pacmod_msgs::YawRateRptConstPtr& msg);
+        void gearCallback(const j2735_msgs::TransmissionStateConstPtr& msg);
+        void speedCallback(const std_msgs::Float64ConstPtr& msg);
+        void headingCallback(const novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr& msg);
+        void steerWheelAngleCallback(const std_msgs::Float64ConstPtr& msg);
+        void brakeCallback(const std_msgs::Float64ConstPtr& msg);
+
+        // callback for the timer
+        void generateBSM(const ros::TimerEvent& event);
+
+    };
+
+}

--- a/bsm_generator/include/bsm_generator_worker.h
+++ b/bsm_generator/include/bsm_generator_worker.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <vector>
+#include <ros/ros.h>
+#include <stdint.h>
+#include <algorithm>
+
+namespace bsm_generator
+{
+    class BSMGeneratorWorker
+    {
+        public:
+
+            BSMGeneratorWorker();
+
+            uint8_t getNextMsgCount();
+            std::vector<uint8_t> getMsgId(const ros::Time now);
+            uint16_t getSecMark(const ros::Time now);
+            float getSpeedInRange(const double speed);
+            float getSteerWheelAngleInRnage(const double angle);
+
+        private:
+
+            // variables for BSM generation
+            uint8_t msg_count;
+            int random_id;
+            ros::Time last_id_generation_time;
+    };
+}

--- a/bsm_generator/include/bsm_generator_worker.h
+++ b/bsm_generator/include/bsm_generator_worker.h
@@ -34,6 +34,9 @@ namespace bsm_generator
             uint16_t getSecMark(const ros::Time now);
             float getSpeedInRange(const double speed);
             float getSteerWheelAngleInRnage(const double angle);
+            float getLongAccelInRange(const float accel);
+            float getYawRateInRange(const double yaw_rate);
+            uint8_t getBrakeAppliedStatus(const double brake);
 
         private:
 

--- a/bsm_generator/include/bsm_generator_worker.h
+++ b/bsm_generator/include/bsm_generator_worker.h
@@ -37,6 +37,7 @@ namespace bsm_generator
             float getLongAccelInRange(const float accel);
             float getYawRateInRange(const double yaw_rate);
             uint8_t getBrakeAppliedStatus(const double brake);
+            float getHeadingInRange(const float heading);
 
         private:
 

--- a/bsm_generator/launch/bsm_generator.launch
+++ b/bsm_generator/launch/bsm_generator.launch
@@ -1,0 +1,19 @@
+<!--
+  Copyright (C) 2018-2019 LEIDOS.
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+  This file is used to launch a ros wrapper of Autoware planner as a CARMA strategic plugin.
+-->
+<launch>
+    <rosparam command="load" file="$(find bsm_generator)/config/parameters.yaml"/>
+    <node name="bsm_generator" pkg="bsm_generator" type="bsm_generator"/>
+</launch>

--- a/bsm_generator/package.xml
+++ b/bsm_generator/package.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+
+<!--  
+ Copyright (C) 2018-2019 LEIDOS.
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+-->
+
+<package format="2">
+  <name>bsm_generator</name>
+  <version>1.0.0</version>
+  <description>This generates BSM according to J2735 standard.</description>
+  <maintainer email="carma@todo.todo">carma</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="carma@todo.todo">carma</author>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>cav_msgs</depend>
+  <depend>carma_utils</depend>
+  <depend>automotive_platform_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>pacmod_msgs</depend>
+  <depend>j2735_msgs</depend>
+  <depend>novatel_gps_msgs</depend>
+</package>

--- a/bsm_generator/package.xml
+++ b/bsm_generator/package.xml
@@ -33,4 +33,5 @@
   <depend>pacmod_msgs</depend>
   <depend>j2735_msgs</depend>
   <depend>novatel_gps_msgs</depend>
+  <depend>sensor_fusion</depend>
 </package>

--- a/bsm_generator/src/bsm_generator.cpp
+++ b/bsm_generator/src/bsm_generator.cpp
@@ -99,7 +99,6 @@ namespace bsm_generator
             geometry_msgs::TransformStamped tf = tf2_buffer_.lookupTransform("earth", "host_vehicle", ros::Time(0));
             tf2::Vector3 loc(tf.transform.translation.x, tf.transform.translation.y, tf.transform.translation.z);
             // TODO ecef_to_geodesic function is not in the library yet
-            /*
             wgs84_utils::wgs84_coordinate coord =  wgs84_utils::ecef_to_geodesic(loc);
             bsm_.core_data.longitude = coord.lon;
             bsm_.core_data.latitude = coord.lat;
@@ -107,7 +106,6 @@ namespace bsm_generator
             bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.LONGITUDE_AVAILABLE;
             bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.LATITUDE_AVAILABLE;
             bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.ELEVATION_AVAILABLE;
-            */
         }
         catch (tf2::TransformException &ex)
         {

--- a/bsm_generator/src/bsm_generator.cpp
+++ b/bsm_generator/src/bsm_generator.cpp
@@ -26,28 +26,31 @@ namespace bsm_generator
         nh_.reset(new ros::CARMANodeHandle());
         pnh_.reset(new ros::CARMANodeHandle("~"));
         pnh_->param<double>("bsm_generation_frequency", bsm_generation_frequency_, 10.0);
+        nh_->param<double>("vehicle_length", vehicle_length_, 5.0);
+        nh_->param<double>("vehicle_width", vehicle_width_, 2.0);
         bsm_pub_ = nh_->advertise<cav_msgs::BSM>("bsm_outbound", 5);
         timer_ = nh_->createTimer(ros::Duration(1.0 / bsm_generation_frequency_), &BSMGenerator::generateBSM, this);
         gear_sub_ = nh_->subscribe("transmission_state", 1, &BSMGenerator::gearCallback, this);
         speed_sub_ = nh_->subscribe("vehicle_speed", 1, &BSMGenerator::speedCallback, this);
         steer_wheel_angle_sub_ = nh_->subscribe("steering_wheel_angle", 1, &BSMGenerator::steerWheelAngleCallback, this);
-
-        // waypoints_sub_ = nh_->subscribe("final_waypoints", 1, &AutowarePlugin::waypoints_cb, this);
-        //pose_sub_ = nh_->subscribe("current_pose", 1, &BSMGenerator::pose_cb, this);
-        // twist_sub_ = nh_->subscribe("current_velocity", 1, &AutowarePlugin::twist_cd, this);
-        
+        accel_sub_ = nh_->subscribe("velocity_accel", 1, &BSMGenerator::accelCallback, this);
+        yaw_sub_ = nh_->subscribe("yaw_rate_rpt", 1, &BSMGenerator::yawCallback, this);
+        brake_sub_ = nh_->subscribe("brake_position", 1, &BSMGenerator::brakeCallback, this);
     }
 
     void BSMGenerator::initializeBSM()
     {
         bsm_.core_data.presence_vector = 0;
-        bsm_.core_data.transmission.transmission_state = bsm_.core_data.transmission.UNAVAILABLE;
+        bsm_.core_data.size.vehicle_width = vehicle_width_;
+        bsm_.core_data.size.vehicle_length = vehicle_length_;
+        bsm_.core_data.size.presence_vector = bsm_.core_data.size.presence_vector | bsm_.core_data.size.VEHICLE_LENGTH_AVAILABLE;
+        bsm_.core_data.size.presence_vector = bsm_.core_data.size.presence_vector | bsm_.core_data.size.VEHICLE_WIDTH_AVAILABLE;
     }
 
     void BSMGenerator::run()
     {
-        initializeBSM();
         initialize();
+        initializeBSM();
         ros::CARMANodeHandle::spin();
     }
 
@@ -64,7 +67,25 @@ namespace bsm_generator
 
     void BSMGenerator::steerWheelAngleCallback(const std_msgs::Float64ConstPtr& msg)
     {
-        
+        bsm_.core_data.angle = worker.getSteerWheelAngleInRnage(msg->data);
+        bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.STEER_WHEEL_ANGLE_AVAILABLE;
+    }
+
+    void BSMGenerator::accelCallback(const automotive_platform_msgs::VelocityAccelConstPtr& msg)
+    {
+        bsm_.core_data.accelSet.longitudinal = worker.getLongAccelInRange(msg->accleration);
+        bsm_.core_data.accelSet.presence_vector = bsm_.core_data.accelSet.presence_vector | bsm_.core_data.accelSet.ACCELERATION_AVAILABLE;
+    }
+
+    void BSMGenerator::yawCallback(const pacmod_msgs::YawRateRptConstPtr& msg)
+    {
+        bsm_.core_data.accelSet.yaw_rate = worker.getYawRateInRange(msg->yaw_rate);
+        bsm_.core_data.accelSet.presence_vector = bsm_.core_data.accelSet.presence_vector | bsm_.core_data.accelSet.YAWRATE_AVAILABLE;
+    }
+
+    void BSMGenerator::brakeCallback(const std_msgs::Float64ConstPtr& msg)
+    {
+        bsm_.core_data.brakes.wheelBrakes.brake_applied_status = worker.getBrakeAppliedStatus(msg->data);
     }
 
     void BSMGenerator::generateBSM(const ros::TimerEvent& event)
@@ -76,7 +97,6 @@ namespace bsm_generator
         bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.SEC_MARK_AVAILABLE;
         // currently the accuracy is not available because ndt_matching does not provide accuracy measurement
         bsm_.core_data.accuracy.presence_vector = 0;
-
         bsm_pub_.publish(bsm_);
     }
 }

--- a/bsm_generator/src/bsm_generator.cpp
+++ b/bsm_generator/src/bsm_generator.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+#include "bsm_generator.h"
+
+namespace bsm_generator
+{
+    BSMGenerator::BSMGenerator() : bsm_generation_frequency_(10.0) {}
+
+    void BSMGenerator::initialize()
+    {
+        nh_.reset(new ros::CARMANodeHandle());
+        pnh_.reset(new ros::CARMANodeHandle("~"));
+        pnh_->param<double>("bsm_generation_frequency", bsm_generation_frequency_, 10.0);
+        bsm_pub_ = nh_->advertise<cav_msgs::BSM>("bsm_outbound", 5);
+        timer_ = nh_->createTimer(ros::Duration(1.0 / bsm_generation_frequency_), &BSMGenerator::generateBSM, this);
+        gear_sub_ = nh_->subscribe("transmission_state", 1, &BSMGenerator::gearCallback, this);
+        speed_sub_ = nh_->subscribe("vehicle_speed", 1, &BSMGenerator::speedCallback, this);
+        steer_wheel_angle_sub_ = nh_->subscribe("steering_wheel_angle", 1, &BSMGenerator::steerWheelAngleCallback, this);
+
+        // waypoints_sub_ = nh_->subscribe("final_waypoints", 1, &AutowarePlugin::waypoints_cb, this);
+        //pose_sub_ = nh_->subscribe("current_pose", 1, &BSMGenerator::pose_cb, this);
+        // twist_sub_ = nh_->subscribe("current_velocity", 1, &AutowarePlugin::twist_cd, this);
+        
+    }
+
+    void BSMGenerator::initializeBSM()
+    {
+        bsm_.core_data.presence_vector = 0;
+        bsm_.core_data.transmission.transmission_state = bsm_.core_data.transmission.UNAVAILABLE;
+    }
+
+    void BSMGenerator::run()
+    {
+        initializeBSM();
+        initialize();
+        ros::CARMANodeHandle::spin();
+    }
+
+    void BSMGenerator::speedCallback(const std_msgs::Float64ConstPtr& msg)
+    {
+        bsm_.core_data.speed = worker.getSpeedInRange(msg->data);
+        bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.SPEED_AVAILABLE;
+    }
+
+    void BSMGenerator::gearCallback(const j2735_msgs::TransmissionStateConstPtr& msg)
+    {
+        bsm_.core_data.transmission.transmission_state = msg->transmission_state;
+    }
+
+    void BSMGenerator::steerWheelAngleCallback(const std_msgs::Float64ConstPtr& msg)
+    {
+        
+    }
+
+    void BSMGenerator::generateBSM(const ros::TimerEvent& event)
+    {
+        bsm_.header.stamp = ros::Time::now();
+        bsm_.core_data.msg_count = worker.getNextMsgCount();
+        bsm_.core_data.id = worker.getMsgId(ros::Time::now());
+        bsm_.core_data.sec_mark = worker.getSecMark(ros::Time::now());
+        bsm_.core_data.presence_vector = bsm_.core_data.presence_vector | bsm_.core_data.SEC_MARK_AVAILABLE;
+        // currently the accuracy is not available because ndt_matching does not provide accuracy measurement
+        bsm_.core_data.accuracy.presence_vector = 0;
+
+        bsm_pub_.publish(bsm_);
+    }
+}

--- a/bsm_generator/src/bsm_generator_worker.cpp
+++ b/bsm_generator/src/bsm_generator_worker.cpp
@@ -76,6 +76,11 @@ namespace bsm_generator
 
     uint8_t BSMGeneratorWorker::getBrakeAppliedStatus(const double brake)
     {
-        return brake > 0.01 ? 0b1111 : 0;
+        return brake > 0.001 ? 0b1111 : 0;
+    }
+
+    float BSMGeneratorWorker::getHeadingInRange(const float heading)
+    {
+        return std::max(std::min(heading, 359.9875f), 0.0f);
     }
 }

--- a/bsm_generator/src/bsm_generator_worker.cpp
+++ b/bsm_generator/src/bsm_generator_worker.cpp
@@ -76,7 +76,7 @@ namespace bsm_generator
 
     uint8_t BSMGeneratorWorker::getBrakeAppliedStatus(const double brake)
     {
-        return brake > 0.01 ? 0b1111 : 0;
+        return brake >= 0.05 ? 0b1111 : 0;
     }
 
     float BSMGeneratorWorker::getHeadingInRange(const float heading)

--- a/bsm_generator/src/bsm_generator_worker.cpp
+++ b/bsm_generator/src/bsm_generator_worker.cpp
@@ -76,7 +76,7 @@ namespace bsm_generator
 
     uint8_t BSMGeneratorWorker::getBrakeAppliedStatus(const double brake)
     {
-        return brake > 0.001 ? 0b1111 : 0;
+        return brake > 0.01 ? 0b1111 : 0;
     }
 
     float BSMGeneratorWorker::getHeadingInRange(const float heading)

--- a/bsm_generator/src/bsm_generator_worker.cpp
+++ b/bsm_generator/src/bsm_generator_worker.cpp
@@ -61,6 +61,21 @@ namespace bsm_generator
 
     float BSMGeneratorWorker::getSteerWheelAngleInRnage(const double angle)
     {
-        return static_cast<float>(std::max(std::min(angle, 189.0), -189.0));
+        return static_cast<float>(std::max(std::min(angle * 57.2958, 189.0), -189.0));
+    }
+
+    float BSMGeneratorWorker::getLongAccelInRange(const float accel)
+    {
+        return std::max(std::min(accel, 20.0f), -20.0f);
+    }
+
+    float BSMGeneratorWorker::getYawRateInRange(const double yaw_rate)
+    {
+        return static_cast<float>(std::max(std::min(yaw_rate, 327.67), -327.67));
+    }
+
+    uint8_t BSMGeneratorWorker::getBrakeAppliedStatus(const double brake)
+    {
+        return brake > 0.01 ? 0b1111 : 0;
     }
 }

--- a/bsm_generator/src/bsm_generator_worker.cpp
+++ b/bsm_generator/src/bsm_generator_worker.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "bsm_generator_worker.h"
+#include <stdlib.h>
+#include <ros/ros.h>
+
+namespace bsm_generator
+{
+    BSMGeneratorWorker::BSMGeneratorWorker() : msg_count(0) {}
+    
+    uint8_t BSMGeneratorWorker::getNextMsgCount()
+    {
+        uint8_t old_msg_count = msg_count++;
+        if(msg_count == 128)
+        {
+            msg_count = 0;
+        }
+        return old_msg_count;
+    }
+
+    std::vector<uint8_t> BSMGeneratorWorker::getMsgId(const ros::Time now)
+    {
+        std::vector<uint8_t> id(4);
+        // need to change ID every 5 mins
+        ros::Duration id_timeout(60 * 5);
+        if(now - last_id_generation_time >= id_timeout)
+        {
+            random_id = rand();
+            last_id_generation_time = now;
+        }
+        for(int i = 0; i < id.size(); ++i)
+        {
+            id[i] = random_id >> (8 * i);
+        }
+        return id;
+    }
+
+    uint16_t BSMGeneratorWorker::getSecMark(const ros::Time now)
+    {
+        return static_cast<uint16_t>((now.toNSec() / 1000000) % 60000);
+    }
+
+    float BSMGeneratorWorker::getSpeedInRange(const double speed)
+    {
+        return static_cast<float>(std::max(std::min(speed, 163.8), 0.0));
+    }
+
+    float BSMGeneratorWorker::getSteerWheelAngleInRnage(const double angle)
+    {
+        return static_cast<float>(std::max(std::min(angle, 189.0), -189.0));
+    }
+}

--- a/bsm_generator/src/main.cpp
+++ b/bsm_generator/src/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <ros/ros.h>
+#include "bsm_generator.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "bsm_generator");
+    bsm_generator::BSMGenerator bg;
+    bg.run();
+    return 0;
+};

--- a/bsm_generator/test/test_bsm_generator_worker.cpp
+++ b/bsm_generator/test/test_bsm_generator_worker.cpp
@@ -90,7 +90,7 @@ TEST(BSMWorkerTest, testBrakeAppliedStatus)
 {
     bsm_generator::BSMGeneratorWorker worker;
     EXPECT_EQ(0b1111, worker.getBrakeAppliedStatus(0.5));
-    EXPECT_EQ(0, worker.getBrakeAppliedStatus(0.009));
+    EXPECT_EQ(0, worker.getBrakeAppliedStatus(0.049));
     EXPECT_EQ(0, worker.getBrakeAppliedStatus(0));
 }
 

--- a/bsm_generator/test/test_bsm_generator_worker.cpp
+++ b/bsm_generator/test/test_bsm_generator_worker.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "autoware_plugin.h"
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+TEST(AutowarePluginTest, testGetWaypointsInTimeBoundary1)
+{
+    // compose a list of waypoints spanning 8 seconds
+    std::vector<autoware_msgs::Waypoint> waypoints;
+    autoware_msgs::Waypoint wp_1;
+    wp_1.twist.twist.linear.x = 2.0;
+    wp_1.pose.pose.position.x = 0.0;
+    autoware_msgs::Waypoint wp_2;
+    wp_2.twist.twist.linear.x = 4.0;
+    wp_2.pose.pose.position.x = 6.0;
+    autoware_msgs::Waypoint wp_3;
+    wp_3.twist.twist.linear.x = 8.0;
+    wp_3.pose.pose.position.x = 24.0;
+    autoware_msgs::Waypoint wp_4;
+    wp_4.twist.twist.linear.x = 8.0;
+    wp_4.pose.pose.position.x = 40.0;
+    autoware_msgs::Waypoint wp_5;
+    wp_5.twist.twist.linear.x = 8.0;
+    wp_5.pose.pose.position.x = 48.0;
+    waypoints.push_back(wp_1);
+    waypoints.push_back(wp_2);
+    waypoints.push_back(wp_3);
+    waypoints.push_back(wp_4);
+    waypoints.push_back(wp_5);
+    autoware_plugin::AutowarePlugin ap;
+    std::vector<autoware_msgs::Waypoint> res = ap.get_waypoints_in_time_boundary(waypoints, 6.0);
+    EXPECT_EQ(4, res.size());
+    EXPECT_NEAR(2.0, res[0].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(0.0, res[0].pose.pose.position.x, 0.01);
+    EXPECT_NEAR(4.0, res[1].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(6.0, res[1].pose.pose.position.x, 0.01);
+    EXPECT_NEAR(8.0, res[2].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(24.0, res[2].pose.pose.position.x, 0.01);
+    EXPECT_NEAR(8.0, res.back().twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(40.0, res.back().pose.pose.position.x, 0.01);
+}
+
+TEST(AutowarePluginTest, testGetWaypointsInTimeBoundary2)
+{
+    // compose a list of waypoints spaning less than 6 seconds
+    std::vector<autoware_msgs::Waypoint> waypoints;
+    autoware_msgs::Waypoint wp_1;
+    wp_1.twist.twist.linear.x = 2.0;
+    wp_1.pose.pose.position.x = 0.0;
+    autoware_msgs::Waypoint wp_2;
+    wp_2.twist.twist.linear.x = 4.0;
+    wp_2.pose.pose.position.x = 6.0;
+    waypoints.push_back(wp_1);
+    waypoints.push_back(wp_2);
+    autoware_plugin::AutowarePlugin ap;
+    std::vector<autoware_msgs::Waypoint> res = ap.get_waypoints_in_time_boundary(waypoints, 6.0);
+    EXPECT_EQ(2, res.size());
+    EXPECT_NEAR(2.0, res[0].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(0.0, res[0].pose.pose.position.x, 0.01);
+    EXPECT_NEAR(4.0, res[1].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(6.0, res[1].pose.pose.position.x, 0.01);
+}
+
+TEST(AutowarePluginTest, testGetWaypointsInTimeBoundary3)
+{
+    // compose a list of waypoints spanning exactly 5 seconds
+    std::vector<autoware_msgs::Waypoint> waypoints;
+    autoware_msgs::Waypoint wp_1;
+    wp_1.twist.twist.linear.x = 2.0;
+    wp_1.pose.pose.position.x = 0.0;
+    autoware_msgs::Waypoint wp_2;
+    wp_2.twist.twist.linear.x = 4.0;
+    wp_2.pose.pose.position.x = 6.0;
+    autoware_msgs::Waypoint wp_3;
+    wp_3.twist.twist.linear.x = 8.0;
+    wp_3.pose.pose.position.x = 24.0;
+    waypoints.push_back(wp_1);
+    waypoints.push_back(wp_2);
+    waypoints.push_back(wp_3);
+    autoware_plugin::AutowarePlugin ap;
+    std::vector<autoware_msgs::Waypoint> res = ap.get_waypoints_in_time_boundary(waypoints, 5.0);
+    EXPECT_EQ(3, res.size());
+    EXPECT_NEAR(2.0, res[0].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(0.0, res[0].pose.pose.position.x, 0.01);
+    EXPECT_NEAR(4.0, res[1].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(6.0, res[1].pose.pose.position.x, 0.01);
+    EXPECT_NEAR(8.0, res[2].twist.twist.linear.x, 0.01);
+    EXPECT_NEAR(24.0, res[2].pose.pose.position.x, 0.01);
+}
+
+TEST(AutowarePluginTest, testCreateUnevenTrajectory1)
+{
+    // compose a list of waypoints, uneven spaced
+    std::vector<autoware_msgs::Waypoint> waypoints;
+    autoware_msgs::Waypoint wp_1;
+    wp_1.twist.twist.linear.x = 2.0;
+    wp_1.pose.pose.position.x = 0.0;
+    autoware_msgs::Waypoint wp_2;
+    wp_2.twist.twist.linear.x = 4.0;
+    wp_2.pose.pose.position.x = 0.5;
+    autoware_msgs::Waypoint wp_3;
+    wp_3.twist.twist.linear.x = 2.0;
+    wp_3.pose.pose.position.x = 1.3;
+    autoware_msgs::Waypoint wp_4;
+    wp_4.twist.twist.linear.x = 4.0;
+    wp_4.pose.pose.position.x = 1.4;
+    autoware_msgs::Waypoint wp_5;
+    wp_5.twist.twist.linear.x = 4.0;
+    wp_5.pose.pose.position.x = 2.0;
+    waypoints.push_back(wp_1);
+    waypoints.push_back(wp_2);
+    waypoints.push_back(wp_3);
+    waypoints.push_back(wp_4);
+    waypoints.push_back(wp_5);
+    autoware_plugin::AutowarePlugin ap;
+    // create pose message to indicate that the current location is on top of the starting waypoint
+    ap.pose_msg_.reset(new geometry_msgs::PoseStamped());
+    std::vector<cav_msgs::TrajectoryPlanPoint> traj = ap.create_uneven_trajectory_from_waypoints(waypoints);
+    EXPECT_EQ(5, traj.size());
+    EXPECT_NEAR(0.0, traj[0].target_time, 0.01);
+    EXPECT_NEAR(0.0, traj[0].x, 0.01);
+    EXPECT_NEAR(0.25, traj[1].target_time / 1e9, 0.01);
+    EXPECT_NEAR(0.5, traj[1].x, 0.01);
+    EXPECT_NEAR(0.45, traj[2].target_time / 1e9, 0.01);
+    EXPECT_NEAR(1.3, traj[2].x, 0.01);
+    EXPECT_NEAR(0.5, traj[3].target_time / 1e9, 0.01);
+    EXPECT_NEAR(1.4, traj[3].x, 0.01);
+    EXPECT_NEAR(0.65, traj[4].target_time / 1e9, 0.01);
+    EXPECT_NEAR(2.0, traj[4].x, 0.01);
+}
+
+TEST(AutowarePluginTest, testCreateUnevenTrajectory2)
+{
+    // compose a list of waypoints, uneven spaced
+    std::vector<autoware_msgs::Waypoint> waypoints;
+    autoware_msgs::Waypoint wp_1;
+    wp_1.twist.twist.linear.x = 2.0;
+    wp_1.pose.pose.position.x = 0.0;
+    autoware_msgs::Waypoint wp_2;
+    wp_2.twist.twist.linear.x = 4.0;
+    wp_2.pose.pose.position.x = 0.5;
+    autoware_msgs::Waypoint wp_3;
+    wp_3.twist.twist.linear.x = 2.0;
+    wp_3.pose.pose.position.x = 1.3;
+    autoware_msgs::Waypoint wp_4;
+    wp_4.twist.twist.linear.x = 4.0;
+    wp_4.pose.pose.position.x = 1.4;
+    autoware_msgs::Waypoint wp_5;
+    wp_5.twist.twist.linear.x = 4.0;
+    wp_5.pose.pose.position.x = 2.0;
+    waypoints.push_back(wp_1);
+    waypoints.push_back(wp_2);
+    waypoints.push_back(wp_3);
+    waypoints.push_back(wp_4);
+    waypoints.push_back(wp_5);
+    autoware_plugin::AutowarePlugin ap;
+    // create pose message to indicate that the current location is not near the starting waypoint
+    geometry_msgs::PoseStamped pose;
+    pose.pose.position.x = -1.0;
+    ap.pose_msg_.reset(new geometry_msgs::PoseStamped(pose));
+    std::vector<cav_msgs::TrajectoryPlanPoint> traj = ap.create_uneven_trajectory_from_waypoints(waypoints);
+    EXPECT_EQ(6, traj.size());
+    EXPECT_NEAR(0.0, traj[0].target_time / 1e9, 0.01);
+    EXPECT_NEAR(-1.0, traj[0].x, 0.01);
+    EXPECT_NEAR(0.5, traj[1].target_time / 1e9, 0.01);
+    EXPECT_NEAR(0.0, traj[1].x, 0.01);
+    EXPECT_NEAR(0.75, traj[2].target_time / 1e9, 0.001);
+    EXPECT_NEAR(0.5, traj[2].x, 0.01);
+    EXPECT_NEAR(0.95, traj[3].target_time / 1e9, 0.001);
+    EXPECT_NEAR(1.3, traj[3].x, 0.01);
+    EXPECT_NEAR(1.0, traj[4].target_time / 1e9, 0.001);
+    EXPECT_NEAR(1.4, traj[4].x, 0.01);
+    EXPECT_NEAR(1.15, traj[5].target_time / 1e9, 0.001);
+    EXPECT_NEAR(2.0, traj[5].x, 0.01);
+}
+
+// Run all the tests
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+

--- a/bsm_generator/test/test_bsm_generator_worker.cpp
+++ b/bsm_generator/test/test_bsm_generator_worker.cpp
@@ -90,7 +90,7 @@ TEST(BSMWorkerTest, testBrakeAppliedStatus)
 {
     bsm_generator::BSMGeneratorWorker worker;
     EXPECT_EQ(0b1111, worker.getBrakeAppliedStatus(0.5));
-    EXPECT_EQ(0, worker.getBrakeAppliedStatus(0.0009));
+    EXPECT_EQ(0, worker.getBrakeAppliedStatus(0.009));
     EXPECT_EQ(0, worker.getBrakeAppliedStatus(0));
 }
 

--- a/carmajava/launch/message.launch
+++ b/carmajava/launch/message.launch
@@ -32,7 +32,7 @@
 
     <remap from="velocity_accel" to="/hardware_interface/velocity_accel"/>
     <remap from="yaw_rate_rpt" to="/hardware_interface/pacmod/parsed_tx/yaw_rate_rpt"/>
-    <remap from="ndt_pose" to="/localization/ndt_pose"/>
+    <remap from="pose" to="/localization/ndt_pose"/>
     <remap from="transmission_state" to="/hardware_interface/can/transmission_state"/>
     <remap from="vehicle_speed" to="/hardware_interface/pacmod/as_tx/vehicle_speed"/>
     <remap from="dual_antenna_heading" to="/hardware_interface/gnss/dual_antenna_heading"/>
@@ -40,7 +40,9 @@
     <remap from="brake_position" to="/hardware_interface/can/brake_position"/>
 
   <!-- j2735 Convertor Node -->
-  <node pkg="j2735_convertor" type="j2735_convertor_node" name="j2735_convertor"/>
+  <node pkg="j2735_convertor" type="j2735_convertor_node" name="j2735_convertor">
+    <remap from="outgoing_bsm" to="bsm_outbound"/>
+  </node>
   
   <!-- Message Consumer Node -->
   <node pkg="carma" type="message" name="message_consumer" args="gov.dot.fhwa.saxton.carma.message.MessageConsumer">

--- a/carmajava/launch/message.launch
+++ b/carmajava/launch/message.launch
@@ -30,6 +30,15 @@
 
   <remap from="system_alert" to="/system_alert"/>
 
+    <remap from="velocity_accel" to="/hardware_interface/velocity_accel"/>
+    <remap from="yaw_rate_rpt" to="/hardware_interface/pacmod/parsed_tx/yaw_rate_rpt"/>
+    <remap from="ndt_pose" to="/localization/ndt_pose"/>
+    <remap from="transmission_state" to="/hardware_interface/can/transmission_state"/>
+    <remap from="vehicle_speed" to="/hardware_interface/pacmod/as_tx/vehicle_speed"/>
+    <remap from="dual_antenna_heading" to="/hardware_interface/gnss/dual_antenna_heading"/>
+    <remap from="steering_wheel_angle" to="/hardware_interface/can/steering_wheel_angle"/>
+    <remap from="brake_position" to="/hardware_interface/can/brake_position"/>
+
   <!-- j2735 Convertor Node -->
   <node pkg="j2735_convertor" type="j2735_convertor_node" name="j2735_convertor"/>
   
@@ -41,4 +50,7 @@
     <rosparam command="load" file="$(arg PARAM_DIR)/MessageParams.yaml"/>
 
   </node>
+
+  <include file="$(find bsm_generator)/launch/bsm_generator.launch">
+  </include>
 </launch>


### PR DESCRIPTION
# PR Details
BSM Generator Node generates BSM messages at 10Hz by collecting data from the rest of CARMAPlatform.
## Description
BSM Generator node is a standalone ROS node in the CARMA 3 platform. It collects data from multiple sources (e.g., positioning from localization node, speed from CAN driver) and composes basic safety messages (BSMs) for the host vehicle. Generated BSMs will send to the Message package for reformatting and broadcasting.
## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Motivation and Context
Enable BSM capability for connected vehicles.

## How Has This Been Tested?
Unit test passed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
