### PR TITLE
Fix environment variable names in launch files

### DIFF
--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -90,6 +90,7 @@
       <arg name="mock_drivers" value="$(arg mock_drivers)"/>
       <arg name="debug_node" value="$(arg debug_node)"/>
       <arg name="launch_drivers" value="$(arg launch_drivers)"/>
+      <arg name="vehicle_calibration_dir" value="$(arg vehicle_calibration_dir)"/>
     </include>
   </group>
 
@@ -100,6 +101,7 @@
       <arg name="area" value="$(arg area)"/>
       <arg name="load_type" value="$(arg load_type)"/>
       <arg name="single_pcd_path" value="$(arg single_pcd_path)"/>
+      <arg name="vehicle_calibration_dir" value="$(arg vehicle_calibration_dir)"/>
     </include>
   </group>
 
@@ -117,7 +119,9 @@
 
   <!-- Guidance Stack -->
   <group ns="$(env CARMA_GUIDE_NS)">
-    <include file="$(find carma)/launch/guidance.launch"/>
+    <include file="$(find carma)/launch/guidance.launch">
+      <arg name="route_file_folder" value="$(arg route_file_folder)"/>
+    </include>
   </group>
 
   <!-- UI Stack -->
@@ -126,5 +130,5 @@
   </group>
 
   <!-- TODO should there be a data collection launch file. Record Rosbag of all topics excluding /rosout and CAN messages since they may contain sensetive data -->
-  <node pkg="rosbag" type="record" name="rosbag_node" args="record -o /opt/carma/logs/ -a -x '/rosout(.*)|(.*)/received_messages|(.*)/sent_messages'" if="$(arg use_rosbag)" />
+  <node pkg="rosbag" type="record" name="rosbag_node" args="record -o /opt/carma/logs/ --lz4 -a -x '/rosout(.*)|(.*)/received_messages|(.*)/sent_messages|(.*)/ds_fusion/(.*)|(.*)/scan'" if="$(arg use_rosbag)" />
 </launch>

--- a/carmajava/launch/drivers.launch
+++ b/carmajava/launch/drivers.launch
@@ -25,5 +25,6 @@ If not using simulated drivers they are activated if the respective mock argumen
 
 <launch>
   <arg name="mock_drivers" default="controller can comms gnss radar lidar camera roadway_sensor" />
+  <arg name="vehicle_calibration_dir" value="$(arg vehicle_calibration_dir)"/>
   <!-- File not used in development environment where only mock drivers are used -->
 </launch>

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -23,30 +23,30 @@
   <arg name="route_file_folder" default="$(find carma)/routes" doc="Path of folder containing routes to load"/>
   
   <!-- Remap topics from external packages -->
-  <remap from="bsm" to="$(optenv MSG_NS)/outgoing_bsm"/>
-  <remap from="incoming_map" to="$(optenv MSG_NS)/incoming_map"/>
-  <remap from="incoming_spat" to="$(optenv MSG_NS)/incoming_spat"/>
-  <remap from="outgoing_mobility_operation" to="$(optenv MSG_NS)/outgoing_mobility_operation"/>
-  <remap from="outgoing_mobility_request" to="$(optenv MSG_NS)/outgoing_mobility_request"/>
-  <remap from="outgoing_mobility_response" to="$(optenv MSG_NS)/outgoing_mobility_response"/>
+  <remap from="bsm" to="$(optenv CARMA_MSG_NS)/outgoing_bsm"/>
+  <remap from="incoming_map" to="$(optenv CARMA_MSG_NS)/incoming_map"/>
+  <remap from="incoming_spat" to="$(optenv CARMA_MSG_NS)/incoming_spat"/>
+  <remap from="outgoing_mobility_operation" to="$(optenv CARMA_MSG_NS)/outgoing_mobility_operation"/>
+  <remap from="outgoing_mobility_request" to="$(optenv CARMA_MSG_NS)/outgoing_mobility_request"/>
+  <remap from="outgoing_mobility_response" to="$(optenv CARMA_MSG_NS)/outgoing_mobility_response"/>
 
-  <remap from="heading" to="$(optenv INTR_NS)/gnss/heading_raw"/>
-  <remap from="nav_sat_fix" to="$(optenv INTR_NS)/gnss/fix_raw"/>
-  <remap from="velocity" to="$(optenv INTR_NS)/gnss/vel_raw"/>
+  <remap from="heading" to="$(optenv CARMA_INTR_NS)/gnss/heading_raw"/>
+  <remap from="nav_sat_fix" to="$(optenv CARMA_INTR_NS)/gnss/fix_raw"/>
+  <remap from="velocity" to="$(optenv CARMA_INTR_NS)/gnss/vel_raw"/>
   
-  <remap from="/republish/cmd_lateral" to="$(optenv INTR_NS)/controller/cmd_lateral"/>
-  <remap from="/republish/cmd_longitudinal_effort" to="$(optenv INTR_NS)/controller/cmd_longitudinal_effort"/>
-  <remap from="/republish/cmd_speed" to="$(optenv INTR_NS)/controller/cmd_speed"/>
-  <remap from="robot_enabled" to="$(optenv INTR_NS)/controller/robot_enabled"/>
-  <remap from="robot_status" to="$(optenv INTR_NS)/controller/robot_status"/>
-  <remap from="/controller/cmd_lateral" to="$(optenv INTR_NS)/controller/cmd_lateral"/>
-  <remap from="/controller/cmd_longitudinal_effort" to="$(optenv INTR_NS)/controller/cmd_longitudinal_effort"/>
-  <remap from="/controller/cmd_speed" to="$(optenv INTR_NS)/controller/cmd_speed"/>
-  <remap from="enable_robotic" to="$(optenv INTR_NS)/controller/enable_robotic"/>
+  <remap from="/republish/cmd_lateral" to="$(optenv CARMA_INTR_NS)/controller/cmd_lateral"/>
+  <remap from="/republish/cmd_longitudinal_effort" to="$(optenv CARMA_INTR_NS)/controller/cmd_longitudinal_effort"/>
+  <remap from="/republish/cmd_speed" to="$(optenv CARMA_INTR_NS)/controller/cmd_speed"/>
+  <remap from="robot_enabled" to="$(optenv CARMA_INTR_NS)/controller/robot_enabled"/>
+  <remap from="robot_status" to="$(optenv CARMA_INTR_NS)/controller/robot_status"/>
+  <remap from="/controller/cmd_lateral" to="$(optenv CARMA_INTR_NS)/controller/cmd_lateral"/>
+  <remap from="/controller/cmd_longitudinal_effort" to="$(optenv CARMA_INTR_NS)/controller/cmd_longitudinal_effort"/>
+  <remap from="/controller/cmd_speed" to="$(optenv CARMA_INTR_NS)/controller/cmd_speed"/>
+  <remap from="enable_robotic" to="$(optenv CARMA_INTR_NS)/controller/enable_robotic"/>
 
-  <remap from="ui_instructions" to="$(optenv UI_NS)/ui_instructions"/>
+  <remap from="ui_instructions" to="$(optenv CARMA_UI_NS)/ui_instructions"/>
 
-  <remap from="get_transform" to="$(optenv TF_NS)/get_transform"/>
+  <remap from="get_transform" to="$(optenv CARMA_TF_NS)/get_transform"/>
 
   <!-- TODO Look into if there is a better way for handling global prameters -->
   <remap from="~vehicle_id" to="/vehicle_id"/> 
@@ -63,9 +63,9 @@
   <remap from="trajectory" to="plan_trajectory"/>
   <!-- TODO use arguments for top level namespace -->
   <remap from="trajectory_plan" to="/guidance/pure_pursuit/trajectory"/>
-  <remap from="current_pose" to="$(optenv LOCZ_NS)/ndt_pose"/>
-  <remap from="current_velocity" to="$(optenv INTR_NS)/vehicle/twist"/>
-  <remap from="controller/enable_robotic" to="$(optenv INTR_NS)/controller/enable_robotic"/>
+  <remap from="current_pose" to="$(optenv CARMA_LOCZ_NS)/ndt_pose"/>
+  <remap from="current_velocity" to="$(optenv CARMA_INTR_NS)/vehicle/twist"/>
+  <remap from="controller/enable_robotic" to="$(optenv CARMA_INTR_NS)/controller/enable_robotic"/>
 
   <!-- Substitute UI integration node for Guidance Main -->
   <include file="$(find ui_integration)/launch/ui_integration.launch"/>
@@ -98,7 +98,7 @@
     <remap from="/ctrl_mode" to="ctrl_mode"/>
     <remap from="/emergency_stop" to="emergency_stop"/>
     <remap from="/state_cmd" to="state_cmd"/>
-    <remap from="/vehicle_cmd" to="$(optenv INTR_NS)/vehicle_cmd"/>
+    <remap from="/vehicle_cmd" to="$(optenv CARMA_INTR_NS)/vehicle_cmd"/>
     <include file="$(find waypoint_follower)/launch/twist_filter.launch"/>
   </group>
 

--- a/carmajava/launch/hardware_interface.launch
+++ b/carmajava/launch/hardware_interface.launch
@@ -18,6 +18,9 @@
 	Launch file for launching the nodes in the CARMA hardware interface stack 
 -->
 <launch>
+
+  <arg name="vehicle_calibration_dir" default="$(find carma)../../CARMAVehicleCalibration/development/vehicle" doc="The directory continaing vehicle calibration type parameters"/>
+
   <!-- Simulated Driver Arguments -->
   <!-- Simulation Usage -->
   <arg name="mock_drivers" default="controller can comms gnss radar lidar camera roadway_sensor" doc="List of driver node base names which will be launched as mock drivers"/>
@@ -30,7 +33,7 @@
   <arg name="debug_node" default="" doc="Set to the java node base name to enable debugging on that node. Requires JVM_DEBUG_OPTS environment variable to be set"/>
 
   <!-- Remap topics from external packages -->
-  <remap from="ui_instructions" to="$(optenv UI_NS)/ui_instructions"/>
+  <remap from="ui_instructions" to="$(optenv CARMA_UI_NS)/ui_instructions"/>
 
   <remap from="system_alert" to="/system_alert"/>
 
@@ -44,6 +47,7 @@
     <!-- Driver Launch File if Using Actual Drivers -->
     <include file="$(find carma)/launch/drivers.launch">
       <arg name="mock_drivers" value="$(arg mock_drivers)" />
+      <arg name="vehicle_calibration_dir" value="$(arg vehicle_calibration_dir)"/>
     </include>
   </group>
 

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -19,6 +19,7 @@
 -->
 <launch>
 
+  <arg name="vehicle_calibration_dir" default="$(find carma)../../CARMAVehicleCalibration/development/vehicle" doc="The directory continaing vehicle calibration type parameters"/>
   <arg name="area" default="5x5" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>
   <arg name="arealist_path" default="arealist.txt" doc="Path to the arealist.txt file which contains the paths and dimensions of each map cell to load"/>
   <arg name="load_type" default="noupdate" doc="Enum of the map loading approach to use. Can be 'download', 'noupdate', or 'arealist'"/> 
@@ -46,12 +47,12 @@
   <remap from="/time_ndt_matching" to="time_ndt_matching"/>
 
   <!-- Remap topics from external packages -->
-  <remap from="imu_raw" to="$(optenv INTR_NS)/imu/imu_raw"/>
+  <remap from="imu_raw" to="$(optenv CARMA_INTR_NS)/imu/imu_raw"/>
 
   <remap from="system_alert" to="/system_alert"/>
 
-  <remap from="bestpos" to="$(optenv INTR_NS)/bestpos"/>
-  <remap from="dual_antenna_heading" to="$(optenv INTR_NS)/gnss/dual_antenna_heading"/>
+  <remap from="bestpos" to="$(optenv CARMA_INTR_NS)/bestpos"/>
+  <remap from="dual_antenna_heading" to="$(optenv CARMA_INTR_NS)/gnss/dual_antenna_heading"/>
   
   <!-- <arg name="current_twist" default="current_twist" doc="Remapping of the twist topic used by the deadreckoner node"/>
   <arg name="current_odom" default="current_odom" doc="Remapping of the twist topic used by the deadreckoner node"/> -->
@@ -66,17 +67,9 @@
 
   <!-- NDT Matching-->
   <!-- This namesapce sets the parameters which are not set by default in the ndt_matching.launch file -->
-  <!-- These parameters are not in the ndt_matching node private namespace-->
-  <!-- TODO resolve code duplication. These parameters already exist in base_link->velodyne tf -->
+  <!-- These parameters are not in the ndt_matching node private namespace -->
 
-  <param name="localizer" value="velodyne" />
-  <param name="tf_x" value="1.02" />
-  <param name="tf_y" value="0.0" />
-  <param name="tf_z" value="2.23" />
-  <param name="tf_roll" value="0.0" />
-  <param name="tf_pitch" value="0.0" />
-  <param name="tf_yaw" value="0.0" />
-  
+  <rosparam command="load" file="$(arg vehicle_calibration_dir)/lidar_localizer/ndt_matching/params.yaml"/>
 
   <include file="$(find lidar_localizer)/launch/ndt_matching.launch">
     <arg name="get_height" value="true" />
@@ -89,15 +82,15 @@
 
   <!-- Deadreckoner -->
   <include file="$(find deadreckoner)/launch/deadreckoner.launch">
-    <arg name="current_twist" value="$(optenv INTR_NS)/vehicle/twist" />
+    <arg name="current_twist" value="$(optenv CARMA_INTR_NS)/vehicle/twist" />
     <arg name="current_odom" value="vehicle/odom" />
   </include>
 
   <!-- Voxel Grid Filter -->
   <group>
-  <node pkg="rostopic" type="rostopic" name="config_voxel_grid_filter_rostopic"
-	args="pub -l config/voxel_grid_filter autoware_config_msgs/ConfigVoxelGridFilter '{voxel_leaf_size: 4.0, measurement_range: 100.0}'"
-  />
+    <node pkg="rostopic" type="rostopic" name="config_voxel_grid_filter_rostopic"
+    args="pub -l config/voxel_grid_filter autoware_config_msgs/ConfigVoxelGridFilter '{voxel_leaf_size: 4.0, measurement_range: 100.0}'"
+    />
     <remap from="/points_raw" to="ray_ground_filter/points_no_ground"/>
     <include file="$(find points_downsampler)/launch/points_downsample_remappable.launch">
       <arg name="node_name" value="voxel_grid_filter" />
@@ -105,7 +98,7 @@
   </group>
 
   <!-- Ray Ground Filter -->
-  <remap from="/points_raw" to="$(optenv INTR_NS)/lidar/points_raw"/>
+  <remap from="/points_raw" to="$(optenv CARMA_INTR_NS)/lidar/points_raw"/>
   <include file="$(find points_preprocessor)/launch/ray_ground_filter.launch">
     <arg name="no_ground_point_topic" value="points_no_ground" />
     <arg name="ground_point_topic" value="points_ground" />

--- a/carmajava/launch/message.launch
+++ b/carmajava/launch/message.launch
@@ -23,8 +23,8 @@
   <arg name="debug_msg_consumer" value="$(eval arg('debug_node') == 'message_consumer')"/>
 
   <!-- Remap topics from external packages -->
-  <remap from="inbound_binary_msg" to="$(optenv INTR_NS)/comms/inbound_binary_msg"/>
-  <remap from="outbound_binary_msg" to="$(optenv INTR_NS)/comms/outbound_binary_msg"/>
+  <remap from="inbound_binary_msg" to="$(optenv CARMA_INTR_NS)/comms/inbound_binary_msg"/>
+  <remap from="outbound_binary_msg" to="$(optenv CARMA_INTR_NS)/comms/outbound_binary_msg"/>
 
   <remap from="system_alert" to="/system_alert"/>
 

--- a/carmajava/launch/ui.launch
+++ b/carmajava/launch/ui.launch
@@ -21,38 +21,38 @@
 
   <rosparam command="load" file="$(find carma)/ui/config/CommandAPIParams.yaml"/>
 
-  <remap from="get_available_routes" to="$(optenv GUIDE_NS)/get_available_routes"/>
-  <remap from="set_active_route" to="$(optenv GUIDE_NS)/set_active_route"/>
-  <remap from="start_active_route" to="$(optenv GUIDE_NS)/start_active_route"/>
-  <remap from="route_state" to="$(optenv GUIDE_NS)/route_state"/>
-  <remap from="route_event" to="$(optenv GUIDE_NS)/route_event"/>
-  <remap from="route" to="$(optenv GUIDE_NS)/route"/>
-  <remap from="get_system_version" to="$(optenv GUIDE_NS)/get_system_version"/>
-  <remap from="state" to="$(optenv GUIDE_NS)/state"/>
-  <remap from="ui_platoon_vehicle_info" to="$(optenv GUIDE_NS)/ui_platoon_vehicle_info"/>
-  <remap from="plugins/available_plugins" to="$(optenv GUIDE_NS)/plugins/available_plugins"/>
-  <remap from="plugins/get_registered_plugins" to="$(optenv GUIDE_NS)/plugins/get_registered_plugins"/>
-  <remap from="plugins/activate_plugin" to="$(optenv GUIDE_NS)/plugins/activate_plugin"/>
-  <remap from="set_guidance_active" to="$(optenv GUIDE_NS)/set_guidance_active"/>
-  <remap from="plugins/controlling_plugins" to="$(optenv GUIDE_NS)/plugins/controlling_plugins"/>
-  <remap from="traffic_signal_info" to="$(optenv GUIDE_NS)/traffic_signal_info"/>
-  <remap from="platooning_info" to="$(optenv GUIDE_NS)/platooning_info"/>
-  <remap from="traffic_signal_info" to="$(optenv GUIDE_NS)/traffic_signal_info"/>
+  <remap from="get_available_routes" to="$(optenv CARMA_GUIDE_NS)/get_available_routes"/>
+  <remap from="set_active_route" to="$(optenv CARMA_GUIDE_NS)/set_active_route"/>
+  <remap from="start_active_route" to="$(optenv CARMA_GUIDE_NS)/start_active_route"/>
+  <remap from="route_state" to="$(optenv CARMA_GUIDE_NS)/route_state"/>
+  <remap from="route_event" to="$(optenv CARMA_GUIDE_NS)/route_event"/>
+  <remap from="route" to="$(optenv CARMA_GUIDE_NS)/route"/>
+  <remap from="get_system_version" to="$(optenv CARMA_GUIDE_NS)/get_system_version"/>
+  <remap from="state" to="$(optenv CARMA_GUIDE_NS)/state"/>
+  <remap from="ui_platoon_vehicle_info" to="$(optenv CARMA_GUIDE_NS)/ui_platoon_vehicle_info"/>
+  <remap from="plugins/available_plugins" to="$(optenv CARMA_GUIDE_NS)/plugins/available_plugins"/>
+  <remap from="plugins/get_registered_plugins" to="$(optenv CARMA_GUIDE_NS)/plugins/get_registered_plugins"/>
+  <remap from="plugins/activate_plugin" to="$(optenv CARMA_GUIDE_NS)/plugins/activate_plugin"/>
+  <remap from="set_guidance_active" to="$(optenv CARMA_GUIDE_NS)/set_guidance_active"/>
+  <remap from="plugins/controlling_plugins" to="$(optenv CARMA_GUIDE_NS)/plugins/controlling_plugins"/>
+  <remap from="traffic_signal_info" to="$(optenv CARMA_GUIDE_NS)/traffic_signal_info"/>
+  <remap from="platooning_info" to="$(optenv CARMA_GUIDE_NS)/platooning_info"/>
+  <remap from="traffic_signal_info" to="$(optenv CARMA_GUIDE_NS)/traffic_signal_info"/>
   <remap from="system_alert" to="/system_alert"/>
 
-  <remap from="bsm" to="$(optenv MSG_NS)/incoming_bsm"/>
+  <remap from="bsm" to="$(optenv CARMA_MSG_NS)/incoming_bsm"/>
 
-  <remap from="nav_sat_fix" to="$(optenv INTR_NS)/gnss/nav_sat_fix"/>
-  <remap from="velocity" to="$(optenv INTR_NS)/vehicle/twist"/>
-  <remap from="driver_discovery" to="$(optenv INTR_NS)/driver_discovery"/>
-  <remap from="get_drivers_with_capabilities" to="$(optenv INTR_NS)/get_drivers_with_capabilities"/>
-  <remap from="controller/robotic_status" to="$(optenv INTR_NS)/controller/robot_status"/>
-  <remap from="controller/vehicle_cmd" to="$(optenv INTR_NS)/controller/vehicle_cmd"/>
-  <remap from="comms/outbound_binary_msg" to="$(optenv INTR_NS)/comms/outbound_binary_msg"/>
-  <remap from="comms/inbound_binary_msg" to="$(optenv INTR_NS)/comms/inbound_binary_msg"/>
-  <remap from="can/engine_speed" to="$(optenv INTR_NS)/can/engine_speed"/>
-  <remap from="can/speed" to="$(optenv INTR_NS)/can/speed"/>
-  <remap from="can/acc_engaged" to="$(optenv INTR_NS)/can/acc_engaged"/>
+  <remap from="nav_sat_fix" to="$(optenv CARMA_INTR_NS)/gnss/nav_sat_fix"/>
+  <remap from="velocity" to="$(optenv CARMA_INTR_NS)/vehicle/twist"/>
+  <remap from="driver_discovery" to="$(optenv CARMA_INTR_NS)/driver_discovery"/>
+  <remap from="get_drivers_with_capabilities" to="$(optenv CARMA_INTR_NS)/get_drivers_with_capabilities"/>
+  <remap from="controller/robotic_status" to="$(optenv CARMA_INTR_NS)/controller/robot_status"/>
+  <remap from="controller/vehicle_cmd" to="$(optenv CARMA_INTR_NS)/controller/vehicle_cmd"/>
+  <remap from="comms/outbound_binary_msg" to="$(optenv CARMA_INTR_NS)/comms/outbound_binary_msg"/>
+  <remap from="comms/inbound_binary_msg" to="$(optenv CARMA_INTR_NS)/comms/inbound_binary_msg"/>
+  <remap from="can/engine_speed" to="$(optenv CARMA_INTR_NS)/can/engine_speed"/>
+  <remap from="can/speed" to="$(optenv CARMA_INTR_NS)/can/speed"/>
+  <remap from="can/acc_engaged" to="$(optenv CARMA_INTR_NS)/can/acc_engaged"/>
 
   <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
     <arg name="port" value="9090"/>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

The environment variables in the launch file did not match those in carma.env. This PR corrects that. In addition it reduces the size of recorded bag files by enabling compression and ignoring data coming from the data speed controller driver which publishes a huge amount of can data. Finally, this adds support for setting the ray_ground_filer sensor height using a vehicle calibration file. 

## How Has This Been Tested?

Launching with docker on the vehicle

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
