### PR TITLE
Update gnss_to_map_convertor to use new gps api

### DIFF
--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -65,7 +65,6 @@
   
   <!-- Map files to load -->
   <arg name="arealist_path" default="arealist.txt" doc="Path to the arealist.txt file which contains the paths and dimensions of each map cell to load"/>
-  <arg name="area" default="5x5" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>
   <arg name="load_type" default="noupdate" doc="Enum of the map loading approach to use. Can be 'download', 'noupdate', or 'arealist'"/> 
   <arg name="single_pcd_path" default="$(find carma)/map/base_map.pcd" doc="Path to the map pcd file if using the noupdate load type"/>
   <arg name="area" default="1x1" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>

--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -31,7 +31,7 @@
 -->
 <launch>
   <!-- Directory of vehicle config parameters -->
-  <arg name="vehicle_config_dir" default="$(find carma)../../CARMAConfig/development/vehicle/config" doc="The directory continaing vehicle config type parameters"/>
+  <arg name="vehicle_config_dir" default="$(find carma)../../CARMAConfig/development" doc="The directory continaing vehicle config type parameters"/>
   <arg name="vehicle_calibration_dir" default="$(find carma)../../CARMAVehicleCalibration/development/vehicle/calibration" doc="The directory continaing vehicle calibration type parameters"/>
 
   <!-- Startup Drivers With Main CARMA System -->

--- a/carmajava/launch/carma_src.launch
+++ b/carmajava/launch/carma_src.launch
@@ -31,8 +31,8 @@
 -->
 <launch>
   <!-- Directory of vehicle config parameters -->
-  <arg name="vehicle_config_dir" default="$(find carma)../../CARMAConfig/development" doc="The directory continaing vehicle config type parameters"/>
-  <arg name="vehicle_calibration_dir" default="$(find carma)../../CARMAVehicleCalibration/development/vehicle" doc="The directory continaing vehicle calibration type parameters"/>
+  <arg name="vehicle_config_dir" default="$(find carma)../../CARMAConfig/development/vehicle/config" doc="The directory continaing vehicle config type parameters"/>
+  <arg name="vehicle_calibration_dir" default="$(find carma)../../CARMAVehicleCalibration/development/vehicle/calibration" doc="The directory continaing vehicle calibration type parameters"/>
 
   <!-- Startup Drivers With Main CARMA System -->
   <arg name="launch_drivers" default="true" doc="True if drivers are to be launched with the CARMA Platform, overrides mock_drivers arg if false"/>

--- a/carmajava/launch/drivers.launch
+++ b/carmajava/launch/drivers.launch
@@ -25,6 +25,6 @@ If not using simulated drivers they are activated if the respective mock argumen
 
 <launch>
   <arg name="mock_drivers" default="controller can comms gnss radar lidar camera roadway_sensor" />
-  <arg name="vehicle_calibration_dir" value="$(arg vehicle_calibration_dir)"/>
+  <arg name="vehicle_calibration_dir" default="$(arg vehicle_calibration_dir)"/>
   <!-- File not used in development environment where only mock drivers are used -->
 </launch>

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -68,7 +68,7 @@
   <remap from="controller/enable_robotic" to="$(optenv CARMA_INTR_NS)/controller/enable_robotic"/>
 
   <!-- Substitute UI integration node for Guidance Main -->
-  <include file="$(find ui_integration)/launch/ui_integration.launch"/>
+  <include file="$(find guidance)/launch/guidance_main.launch"/>
 
   <!-- TODO Check topic remapping-->
   <!-- Control Stack -->

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -47,12 +47,11 @@
   <remap from="/time_ndt_matching" to="time_ndt_matching"/>
 
   <!-- Remap topics from external packages -->
-  <remap from="imu_raw" to="$(optenv CARMA_INTR_NS)/imu/imu_raw"/>
+  <remap from="imu_raw" to="$(optenv CARMA_INTR_NS)/imu_raw"/>
 
   <remap from="system_alert" to="/system_alert"/>
 
-  <remap from="bestpos" to="$(optenv CARMA_INTR_NS)/bestpos"/>
-  <remap from="dual_antenna_heading" to="$(optenv CARMA_INTR_NS)/gnss/dual_antenna_heading"/>
+  <remap from="gnss_fix_fused" to="$(optenv CARMA_INTR_NS)/gnss_fix_fused"/>
   
   <!-- <arg name="current_twist" default="current_twist" doc="Remapping of the twist topic used by the deadreckoner node"/>
   <arg name="current_odom" default="current_odom" doc="Remapping of the twist topic used by the deadreckoner node"/> -->

--- a/gnss_to_map_convertor/include/gnss_to_map_convertor/GNSSToMapConvertor.h
+++ b/gnss_to_map_convertor/include/gnss_to_map_convertor/GNSSToMapConvertor.h
@@ -23,6 +23,7 @@
 #include <novatel_gps_msgs/NovatelDualAntennaHeading.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/Pose.h>
+#include <gps_common/GPSFix.h>
 
 /**
  * \class GNSSToMapNode
@@ -33,13 +34,29 @@
  */
 namespace gnss_to_map_convertor
 {
+  /**
+   * \brief Generates a pose for a vehicle in a map from given the transform to that frame and the gnss fix and heading
+   * 
+   * \param baselink_in_sensor Transform describing the location of the base_link frame in the gnss sensor frame
+   * \param sensor_in_ned_heading Transform describing the location of the sensor frame in the frame in which that sensor reports its heading
+   * \param fix_msg The message containing gnss fix and heading information
+   * 
+   * \return The pose in the map frame
+   */ 
   geometry_msgs::PoseWithCovarianceStamped poseFromGnss(
     const tf2::Transform& baselink_in_sensor,
     const tf2::Transform& sensor_in_ned_heading,
-    const sensor_msgs::NavSatFixConstPtr& fix_msg, 
-    const novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr& heading_msg
+    const gps_common::GPSFixConstPtr& fix_msg
   );
 
+  /**
+   * \brief Generates a pose message for a vehicle in the map frame when provided with that vehicles location in the earth frame and the maps location in the earth frame
+   * 
+   * \param baselink_in_earth Transform describing location of base_link frame in the earth frame
+   * \param map_in_earth Transform describing location of map frame in the earth frame
+   * 
+   * \return geometry_msgs::Pose containing the pose of the vehicle in the map frame
+   */ 
   geometry_msgs::Pose ecefTFToMapPose(const tf2::Transform& baselink_in_earth, const tf2::Transform& map_in_earth);
 
 };

--- a/gnss_to_map_convertor/include/gnss_to_map_convertor/GNSSToMapNode.h
+++ b/gnss_to_map_convertor/include/gnss_to_map_convertor/GNSSToMapNode.h
@@ -54,10 +54,7 @@ namespace gnss_to_map_convertor {
       ros::Publisher ecef_pose_pub_;
       ros::Publisher map_pose_pub_;
 
-      message_filters::Subscriber<novatel_gps_msgs::NovatelPosition> fix_sub_;
-      message_filters::Subscriber<novatel_gps_msgs::NovatelDualAntennaHeading> heading_sub_;
-
-      typedef message_filters::sync_policies::ApproximateTime<novatel_gps_msgs::NovatelPosition, novatel_gps_msgs::NovatelDualAntennaHeading> SyncPolicy;
+      ros::Subscriber fix_sub_;
 
       tf2::Transform baselink_in_sensor_; 
       tf2::Transform sensor_in_ned_; 
@@ -68,12 +65,11 @@ namespace gnss_to_map_convertor {
       std::string ned_heading_frame_ = "ned_heading";
 
       /**
-       * @brief Synchronized NavSatFix and Heading callback which publishes the updated ecef and map poses
+       * @brief GPSFix callback which publishes the updated ecef and map poses
        * 
-       * @param fix_msg The gnss fix providing a location
-       * @param heading_msg The gnss heading and pitch
+       * @param fix_msg The gnss fix message which must contain the position and heading information
        */ 
-      void fixCb(const novatel_gps_msgs::NovatelPositionConstPtr& fix_msg, const novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr& heading_msg);
+      void fixCb(const gps_common::GPSFixConstPtr& fix_msg);
 
     public:
       /**

--- a/gnss_to_map_convertor/src/gnss_to_map_convertor/GNSSToMapConvertor.cpp
+++ b/gnss_to_map_convertor/src/gnss_to_map_convertor/GNSSToMapConvertor.cpp
@@ -36,13 +36,12 @@ namespace gnss_to_map_convertor {
 
     return pose;
   }
-        
+
   geometry_msgs::PoseWithCovarianceStamped poseFromGnss(
     const tf2::Transform& baselink_in_sensor,
     const tf2::Transform& sensor_in_ned_heading,
-    const sensor_msgs::NavSatFixConstPtr& fix_msg,
-    const novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr& heading_msg) {
-
+    const gps_common::GPSFixConstPtr& fix_msg
+  ) {
     const double lat = fix_msg->latitude * wgs84_utils::DEG2RAD;
     const double lon = fix_msg->longitude * wgs84_utils::DEG2RAD;
     const double alt = fix_msg->altitude;
@@ -53,8 +52,8 @@ namespace gnss_to_map_convertor {
 
     const tf2::Vector3 identity_trans(0,0,0);
     tf2::Quaternion heading_in_ned_quat;
-    //heading_in_ned_quat.setRPY(0, heading_msg->pitch * wgs84_utils::DEG2RAD, heading_msg->heading);
-    heading_in_ned_quat.setRPY(0, 0, heading_msg->heading * wgs84_utils::DEG2RAD);
+    //heading_in_ned_quat.setRPY(fix_msg->roll, heading_msg->pitch * wgs84_utils::DEG2RAD, fix_msg->track);
+    heading_in_ned_quat.setRPY(0, 0, fix_msg->track * wgs84_utils::DEG2RAD);
 
     const tf2::Transform T_n_h(heading_in_ned_quat, identity_trans);
 

--- a/gnss_to_map_convertor/src/gnss_to_map_convertor/GNSSToMapNode.cpp
+++ b/gnss_to_map_convertor/src/gnss_to_map_convertor/GNSSToMapNode.cpp
@@ -37,14 +37,8 @@ namespace gnss_to_map_convertor {
       baselink_in_sensor_set_ = true;
     }
 
-    gps_common::GPSFix nav_fix_msg;
-    nav_fix_msg.latitude = fix_msg->latitude;
-    nav_fix_msg.longitude = fix_msg->longitude;
-    nav_fix_msg.altitude = fix_msg->altitude;
-    gps_common::GPSFixConstPtr fix_ptr(new gps_common::GPSFix(nav_fix_msg));
-
     geometry_msgs::PoseWithCovarianceStamped ecef_pose = gnss_to_map_convertor::poseFromGnss(
-      baselink_in_sensor_, sensor_in_ned_, fix_ptr
+      baselink_in_sensor_, sensor_in_ned_, fix_msg
     ); 
     ecef_pose.header.frame_id = earth_frame_; // Set correct frame id
 
@@ -84,7 +78,7 @@ namespace gnss_to_map_convertor {
     // Map pose publisher
     map_pose_pub_ = cnh_.advertise<geometry_msgs::PoseStamped>("gnss_pose", 10, true);
     // Fix Subscriber
-    fix_sub_ = cnh_.subscribe("gnss_fix_fused", 1, &GNSSToMapNode::fixCb, this);
+    fix_sub_ = cnh_.subscribe("gnss_fix_fused", 2, &GNSSToMapNode::fixCb, this);
 
     // Spin
     cnh_.setSpinRate(20);

--- a/gnss_to_map_convertor/test/gnss_to_map_convertor/GNSSToMapConvertorTest.cpp
+++ b/gnss_to_map_convertor/test/gnss_to_map_convertor/GNSSToMapConvertorTest.cpp
@@ -63,22 +63,19 @@ TEST(GNSSToMapConvertor, poseFromGnss)
   sensor_in_ned_heading_quat.setRPY(wgs84_utils::pi, 0, 0); 
   sensor_in_ned_heading.setRotation(sensor_in_ned_heading_quat);
 
-  novatel_gps_msgs::NovatelDualAntennaHeading heading_msg;
-  sensor_msgs::NavSatFix fix_msg;
+  gps_common::GPSFix fix_msg;
 
   // Test point at prime meridian and equator with 0 heading
   fix_msg.latitude = 0;
   fix_msg.longitude = 0;
   fix_msg.altitude = 0;
 
-  heading_msg.heading = 0;
-  heading_msg.pitch = 0;
+  fix_msg.track = 0;
 
-  sensor_msgs::NavSatFixConstPtr fix_ptr(new sensor_msgs::NavSatFix(fix_msg));
-  novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr heading_ptr(new novatel_gps_msgs::NovatelDualAntennaHeading(heading_msg));
+  gps_common::GPSFixConstPtr fix_ptr(new gps_common::GPSFix(fix_msg));
 
   geometry_msgs::PoseWithCovarianceStamped result;
-  result = gnss_to_map_convertor::poseFromGnss(baselink_in_sensor, sensor_in_ned_heading, fix_ptr, heading_ptr);
+  result = gnss_to_map_convertor::poseFromGnss(baselink_in_sensor, sensor_in_ned_heading, fix_ptr);
 
   tf2::Vector3 solTrans(6378137.0, 0, 0);
   tf2::Quaternion solRot;
@@ -94,13 +91,11 @@ TEST(GNSSToMapConvertor, poseFromGnss)
   fix_msg.longitude = 0;
   fix_msg.altitude = 0;
 
-  heading_msg.heading = 90.0;
-  heading_msg.pitch = 0;
+  fix_msg.track = 90.0;
 
-  fix_ptr = sensor_msgs::NavSatFixConstPtr(new sensor_msgs::NavSatFix(fix_msg));
-  heading_ptr = novatel_gps_msgs::NovatelDualAntennaHeadingConstPtr(new novatel_gps_msgs::NovatelDualAntennaHeading(heading_msg));
+  fix_ptr = gps_common::GPSFixConstPtr(new gps_common::GPSFix(fix_msg));
 
-  result = gnss_to_map_convertor::poseFromGnss(baselink_in_sensor, sensor_in_ned_heading, fix_ptr, heading_ptr);
+  result = gnss_to_map_convertor::poseFromGnss(baselink_in_sensor, sensor_in_ned_heading, fix_ptr);
 
   tf2::Vector3 solTrans2(6378137.0, 0, 0);
   tf2::Quaternion solRot2;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->
# PR Details
## Description
Update the gnss_to_map_convertor to use the new GNSS driver api which relies on gps_common/GPSFix messages instead of sensor_msgs/NavSatFix as this message type contains more complete information. This should allow the system to operate without the HEADINGOFFSET being applied to the novatel device which is the source of the GPS issues on the vehicles. 

## Related Issue
#275
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests. Working on integration tests now


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
