### PR TITLE
Remove deprecated repo from repos file

### DIFF
--- a/carma-platform.repos
+++ b/carma-platform.repos
@@ -43,10 +43,6 @@ repositories:
     type: git
     url: git@github.com:usdot-fhwa-stol/CARMANovatelGpsDriver.git
     version: develop
-  CARMAPacmod3CanDriverWrapper:
-    type: git
-    url: git@github.com:usdot-fhwa-stol/CARMAPacmod3CanDriverWrapper.git
-    version: develop
   CARMAPlatform:
     type: git
     url: git@github.com:usdot-fhwa-stol/CARMAPlatform.git


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Resolves #344 by removing the deleted CARMAPacmod3CanDriverWrapper repo from the .repos file.

## How Has This Been Tested?

Successfully ran
```
vcs import < carma-platform.repos
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
