### PR TITLE
Feature/update carma for autoware 1 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/autoware.ai:3.2.0
+      - image: usdotfhwastol/autoware.ai:3.4.0
         user: carma
         environment:
           TERM: xterm

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@
 # Stage 1 - Acquire the CARMA source as well as any extra packages
 # /////////////////////////////////////////////////////////////////////////////
 
-FROM usdotfhwastol/autoware.ai:3.2.0 AS source-code
+FROM usdotfhwastol/autoware.ai:3.4.0 AS source-code
 
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/CARMAPlatform/
@@ -43,7 +43,7 @@ RUN ~/src/CARMAPlatform/docker/checkout.sh
 # Stage 2 - Build and install the software 
 # /////////////////////////////////////////////////////////////////////////////
 
-FROM usdotfhwastol/autoware.ai:3.2.0 AS install
+FROM usdotfhwastol/autoware.ai:3.4.0 AS install
 
 # Copy the source files from the previous stage and build/install
 RUN mkdir ~/carma_ws
@@ -54,7 +54,7 @@ RUN ~/carma_ws/src/CARMAPlatform/docker/install.sh
 # Stage 3 - Finalize deployment
 # /////////////////////////////////////////////////////////////////////////////
 
-FROM usdotfhwastol/autoware.ai:3.2.0
+FROM usdotfhwastol/autoware.ai:3.4.0
 
 ARG BUILD_DATE="NULL"
 ARG VCS_REF="NULL"

--- a/carmajava/launch/guidance.launch
+++ b/carmajava/launch/guidance.launch
@@ -114,7 +114,7 @@
     <remap from="/emergency_stop" to="emergency_stop"/>
     <remap from="/state_cmd" to="state_cmd"/>
     <remap from="/vehicle_cmd" to="$(optenv CARMA_INTR_NS)/vehicle_cmd"/>
-    <include file="$(find waypoint_follower)/launch/twist_filter.launch"/>
+    <include file="$(find twist_filter)/launch/twist_filter.launch"/>
   </group>
 
   <!-- Planning Stack -->

--- a/carmajava/launch/localization.launch
+++ b/carmajava/launch/localization.launch
@@ -101,8 +101,7 @@
 
   <!-- Ray Ground Filter -->
   <remap from="/points_raw" to="$(optenv CARMA_INTR_NS)/lidar/points_raw"/>
-  <include file="$(find points_preprocessor)/launch/ray_ground_filter_file_config.launch">
-    <arg name="vehicle_calibration_params_file" value="$(arg vehicle_calibration_dir)/points_preprocessor/ray_ground_filter/calibration.yaml"/>
+  <include file="$(find points_preprocessor)/launch/ray_ground_filter.launch">
     <arg name="no_ground_point_topic" value="points_no_ground" />
     <arg name="ground_point_topic" value="points_ground" />
   </include>

--- a/carmajava/mock_drivers/build.gradle
+++ b/carmajava/mock_drivers/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   compile 'org.ros.rosjava_messages:diagnostic_msgs:1.12.5'
   compile 'org.ros.rosjava_messages:sensor_msgs:1.12.5'
   compile 'org.ros.rosjava_messages:nav_msgs:1.12.5'
-  compile 'org.ros.rosjava_messages:autoware_msgs:1.11.0'
+  compile 'org.ros.rosjava_messages:autoware_msgs:1.12.0'
   compile 'org.ros.rosjava_messages:derived_object_msgs:2.3.1'
   compile 'org.ros.rosjava_messages:radar_msgs:2.3.1'
   /* Local subproject dependency */

--- a/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockLidarDriver.java
+++ b/carmajava/mock_drivers/src/main/java/gov/dot/fhwa/saxton/carma/mock_drivers/MockLidarDriver.java
@@ -62,7 +62,7 @@ public class MockLidarDriver extends AbstractMockDriver {
     // TODO use actual data from file
     sensor_msgs.PointCloud2 cloud = pointsPub.newMessage();
     // Set Header Data
-    cloud.getHeader().setFrameId("lidar");
+    cloud.getHeader().setFrameId("velodyne");
     cloud.getHeader().setStamp(connectedNode.getCurrentTime());
     pointsPub.publish(cloud);
 

--- a/docs/carma_installation.md
+++ b/docs/carma_installation.md
@@ -35,6 +35,7 @@ containing a base-line configuration of this system are available upon request.
 `sudo apt-get update`
 `sudo apt-get install -y python-catkin-pkg python-rosdep ros-$ROS_DISTRO-catkin gksu`
 `sudo apt-get install -y python3-pip python3-colcon-common-extensions python3-setuptools python3-vcstool`
+`sudo apt-get install -y libgeographic-dev libpugixml-dev python-catkin-tools libboost-python-dev`
 `pip3 install -U setuptools`
 
 6-2- Clone CARMA Packages

--- a/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
+++ b/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
@@ -2,7 +2,7 @@
 <launch>
     <remap from="final_waypoints" to="carma_final_waypoints"/>
     <!-- Pure Pursuit Node -->
-    <include file="$(find waypoint_follower)/launch/pure_pursuit.launch">
+    <include file="$(find pure_pursuit)/launch/pure_pursuit.launch">
         <arg name="is_linear_interpolation" value="True"/>
         <arg name="publishes_for_steering_robot" value="True"/>
     </include>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Updates CARMAPlatform to use Autoware 1.13 pre-release which corresponds to the new component release of usdotfhwastol/autoware.ai:3.4.0

To support this version the following changes are made to CARMAPlatform
- Docker and CI base image version updated
- waypoint_follower package references replaced with twist_filter and pure_pursuit as needed.
- Unnecessary calibration file parameter removed from ray_ground_filter launch file include
- Mock lidar driver updated to use proper frame id which matches default urdf file. 
- Added lanelet2 deps to carma installation guide

## Related Issue

#419 

## Motivation and Context

Allows Lanelet2 integration with CARMAPlatform

## How Has This Been Tested?

Tested running in docker both under development configuration and on the Blue Lexus demo loop at TFHRC

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
