### PR TITLE
Bugfix/arbitrator planning rate

### DIFF
--- a/arbitrator/include/arbitrator.hpp
+++ b/arbitrator/include/arbitrator.hpp
@@ -43,6 +43,7 @@ namespace arbitrator
              * \param sm An ArbitratorStateMachine instance for regulating the states of the Arbitrator
              * \param ci A CapabilitiesInterface for querying plugins
              * \param planning_strategy A planning strategy implementation for generating plans
+             * \param min_plan_duration The minimum acceptable length of a plan
              * \param planning_frequency The frequency at which to generate high-level plans when engaged
              */ 
             Arbitrator(ros::CARMANodeHandle *nh, 
@@ -50,6 +51,7 @@ namespace arbitrator
                 ArbitratorStateMachine *sm, 
                 CapabilitiesInterface *ci, 
                 const PlanningStrategy &planning_strategy,
+                ros::Duration min_plan_duration,
                 ros::Rate planning_frequency):
                 sm_(sm),
                 nh_(nh),
@@ -57,6 +59,7 @@ namespace arbitrator
                 capabilities_interface_(ci),
                 planning_strategy_(planning_strategy),
                 initialized_(false),
+                min_plan_duration_(min_plan_duration),
                 time_between_plans_(planning_frequency.expectedCycleTime()) {};
             
             /**
@@ -106,7 +109,6 @@ namespace arbitrator
             ros::CARMANodeHandle *nh_;
             ros::CARMANodeHandle *pnh_;
             ros::Duration min_plan_duration_;
-            ros::Duration max_plan_duration_;
             ros::Duration time_between_plans_;
             ros::Time next_planning_process_start_;
             CapabilitiesInterface *capabilities_interface_;

--- a/arbitrator/include/arbitrator.hpp
+++ b/arbitrator/include/arbitrator.hpp
@@ -43,18 +43,21 @@ namespace arbitrator
              * \param sm An ArbitratorStateMachine instance for regulating the states of the Arbitrator
              * \param ci A CapabilitiesInterface for querying plugins
              * \param planning_strategy A planning strategy implementation for generating plans
+             * \param planning_frequency The frequency at which to generate high-level plans when engaged
              */ 
             Arbitrator(ros::CARMANodeHandle *nh, 
                 ros::CARMANodeHandle *pnh, 
                 ArbitratorStateMachine *sm, 
                 CapabilitiesInterface *ci, 
-                const PlanningStrategy &planning_strategy):
+                const PlanningStrategy &planning_strategy,
+                ros::Rate planning_frequency):
                 sm_(sm),
                 nh_(nh),
                 pnh_(pnh),
                 capabilities_interface_(ci),
                 planning_strategy_(planning_strategy),
-                initialized_(false) {};
+                initialized_(false),
+                time_between_plans_(planning_frequency.expectedCycleTime()) {};
             
             /**
              * \brief Begin the operation of the arbitrator.

--- a/arbitrator/src/arbitrator.cpp
+++ b/arbitrator/src/arbitrator.cpp
@@ -26,21 +26,26 @@ namespace arbitrator
 {
     void Arbitrator::run()
     {
+        ROS_INFO("Aribtrator started, beginning arbitrator state machine.");
         while (!ros::isShuttingDown())
         {
             ros::spinOnce();
             switch (sm_->get_state()) 
             {
                 case INITIAL:
+                    ROS_INFO("Aribtrator spinning in INITIAL state.");
                     initial_state();
                     break;
                 case PLANNING:
+                    ROS_INFO("Aribtrator spinning in PLANNING state.");
                     planning_state();
                     break;
                 case WAITING:
+                    ROS_INFO("Aribtrator spinning in WAITING state.");
                     waiting_state();
                     break;
                 case PAUSED:
+                    ROS_INFO("Aribtrator spinning in PAUSED state.");
                     paused_state();
                     break;
                 default:
@@ -63,6 +68,7 @@ namespace arbitrator
                 // NO-OP
                 break;
             case cav_msgs::GuidanceState::ENGAGED:
+                ROS_INFO("Received notiace that guidance has been engaged!");
                 if (sm_->get_state() == ArbitratorState::INITIAL) {
                     sm_->submit_event(ArbitratorEvent::SYSTEM_STARTUP_COMPLETE);
                 } else if (sm_->get_state() == ArbitratorState::PAUSED) {
@@ -70,9 +76,11 @@ namespace arbitrator
                 }
                 break;
             case cav_msgs::GuidanceState::INACTIVE:
+                ROS_INFO("Received notiace that guidance has been disengaged, pausing arbitrator.");
                 sm_->submit_event(ArbitratorEvent::ARBITRATOR_PAUSED);
                 break;
             case cav_msgs::GuidanceState::SHUTDOWN:
+                ROS_INFO("Received notiace that guidance has been shutdown, shutting down arbitrator.");
                 sm_->submit_event(ArbitratorEvent::SYSTEM_SHUTDOWN_INITIATED);
                 break;
             default:
@@ -83,7 +91,8 @@ namespace arbitrator
     void Arbitrator::initial_state()
     {
         if(!initialized_)
-        {
+        {   
+            ROS_INFO("Arbitrator initializing on first initial state spin...");
             final_plan_pub_ = nh_->advertise<cav_msgs::ManeuverPlan>("final_maneuver_plan", 5);
             guidance_state_sub_ = nh_->subscribe<cav_msgs::GuidanceState>("guidance_state", 5, &Arbitrator::guidance_state_cb, this);
             initialized_ = true;
@@ -94,23 +103,33 @@ namespace arbitrator
 
     void Arbitrator::planning_state()
     {
+        ROS_INFO("Aribtrator beginning planning process!");
         ros::Time planning_process_start = ros::Time::now();
         cav_msgs::ManeuverPlan plan = planning_strategy_.generate_plan();
-        ros::Time plan_end_time = arbitrator_utils::get_plan_end_time(plan);
-        ros::Time plan_start_time = arbitrator_utils::get_plan_start_time(plan);
-        ros::Duration plan_duration = plan_end_time - plan_start_time;
+        if (!plan.maneuvers.empty()) 
+        {
+            ros::Time plan_end_time = arbitrator_utils::get_plan_end_time(plan);
+            ros::Time plan_start_time = arbitrator_utils::get_plan_start_time(plan);
+            ros::Duration plan_duration = plan_end_time - plan_start_time;
 
-        if (plan_duration < min_plan_duration_) 
-        {
-            ROS_WARN_STREAM("Arbitrator is unable to generate a plan with minimum plan duration requirement!");
-        } 
-        else 
-        {
-            ROS_INFO_STREAM("Arbitrator is publishing plan " << plan.maneuver_plan_id << " of duration " << plan_duration << " as current maneuver plan");
+            if (plan_duration < min_plan_duration_) 
+            {
+                ROS_WARN_STREAM("Arbitrator is unable to generate a plan with minimum plan duration requirement!");
+            } 
+            else 
+            {
+                ROS_INFO_STREAM("Arbitrator is publishing plan " << plan.maneuver_plan_id << " of duration " << plan_duration << " as current maneuver plan");
+            }
+            final_plan_pub_.publish(plan);
         }
-        final_plan_pub_.publish(plan);
+        else
+        {
+            ROS_WARN("Arbitrator was unable to generate a plan!");
+        }
 
         next_planning_process_start_ = planning_process_start + time_between_plans_;
+
+        sm_->submit_event(ArbitratorEvent::PLANNING_COMPLETE);
     }
 
     void Arbitrator::waiting_state()
@@ -121,6 +140,7 @@ namespace arbitrator
         {
             ros::Duration(0.1).sleep();
         }
+        ROS_INFO("Arbitrator transitioning from WAITING to PLANNING state.");
         sm_->submit_event(ArbitratorEvent::PLANNING_TIMER_TRIGGER);
     }
 

--- a/arbitrator/src/arbitrator_node.cpp
+++ b/arbitrator/src/arbitrator_node.cpp
@@ -48,7 +48,9 @@ int main(int argc, char** argv)
     pnh.param("target_duration", target_plan, 15.0);
     arbitrator::TreePlanner tp{fpcf, png, bss, ros::Duration(target_plan)};
 
-    arbitrator::Arbitrator arbitrator{&nh, &pnh, &sm, &ci, tp};
+    double planning_frequency;
+    pnh.param("planning_frequency", planning_frequency, 1.0);
+    arbitrator::Arbitrator arbitrator{&nh, &pnh, &sm, &ci, tp, ros::Rate(planning_frequency)};
 
     arbitrator.run();
 

--- a/arbitrator/src/arbitrator_node.cpp
+++ b/arbitrator/src/arbitrator_node.cpp
@@ -48,9 +48,19 @@ int main(int argc, char** argv)
     pnh.param("target_duration", target_plan, 15.0);
     arbitrator::TreePlanner tp{fpcf, png, bss, ros::Duration(target_plan)};
 
+    double min_plan_duration;
+    pnh.param("min_plan_duration", min_plan_duration, 6.0);
+
     double planning_frequency;
     pnh.param("planning_frequency", planning_frequency, 1.0);
-    arbitrator::Arbitrator arbitrator{&nh, &pnh, &sm, &ci, tp, ros::Rate(planning_frequency)};
+    arbitrator::Arbitrator arbitrator{
+        &nh, 
+        &pnh, 
+        &sm, 
+        &ci, 
+        tp, 
+        ros::Duration(min_plan_duration),
+        ros::Rate(planning_frequency)};
 
     arbitrator.run();
 

--- a/arbitrator/src/capabilities_interface.cpp
+++ b/arbitrator/src/capabilities_interface.cpp
@@ -30,6 +30,7 @@ namespace arbitrator
         static ros::ServiceClient sc = nh_->serviceClient<cav_srvs::PluginList>("/guidance/plugins/get_registered_plugins");
         cav_srvs::PluginList msg;
         if (sc.call(msg)) {
+            capabilities_.clear();
             for (auto it = msg.response.plugins.begin(); it != msg.response.plugins.end(); it++)
             {
                 if (it->activated)

--- a/autoware_plugin/include/autoware_plugin.h
+++ b/autoware_plugin/include/autoware_plugin.h
@@ -82,7 +82,7 @@ namespace autoware_plugin
         std::vector<autoware_msgs::Waypoint> waypoints_list;
 
         // Length of maneuver
-        double mvr_length = 15;
+        double mvr_length = 16;
 
         // Plugin discovery message
         cav_msgs::Plugin plugin_discovery_msg_;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue

Fixes #451 

## Motivation and Context

As per issue #451 the Arbitrator <--> Autoware Plugin interaction was not occurring at the correct frequency (1hz) and was instead occuring at a much lower (0.1hz) frequency. This issue was the result of a confluence of factors:

1. Arbitrator internal timing loop configuration caused it to loop far tighter than anticipated, even though service calls were failing. This issue was masked by the two other factors.
2. A comparison of plan duration ended up comparing two doubles that were supposed to be the same (`ros::Duration(15)` vs the duration of a plan from `ros::Time::now()` to `ros::Time::now() + ros::Duration(15)` but depending on the value of ros::Time::now(), this comparison failed several times before it passed.
3. Plugin discovery was not clearing already discovered plugins from the records when it received new plugin data, thus effectively registering a plugin multiple times and causing extra services calls.

## How Has This Been Tested?

Tested locally via an integration test with the `Arbitrator`, `Health Monitor`, and `Autoware Plugin` nodes.

```rostopic hz /guidance/final_maneuver_plan
subscribed to [/guidance/final_maneuver_plan]
no new messages
no new messages
average rate: 0.953
	min: 1.049s max: 1.049s std dev: 0.00000s window: 2
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00057s window: 3
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00056s window: 4
average rate: 0.953
	min: 1.049s max: 1.051s std dev: 0.00076s window: 5
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00070s window: 6
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00064s window: 7
average rate: 0.953
	min: 1.049s max: 1.051s std dev: 0.00062s window: 8
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00073s window: 9
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00070s window: 10
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00067s window: 11
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00070s window: 12
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00069s window: 13
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00071s window: 14
average rate: 0.952
	min: 1.049s max: 1.051s std dev: 0.00070s window: 15
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
