### PR TITLE
Remap pure_pursuit wheel base parameter to global value

### DIFF
--- a/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
+++ b/pure_pursuit_wrapper/launch/pure_pursuit_wrapper.launch
@@ -2,10 +2,13 @@
 <launch>
     <remap from="final_waypoints" to="carma_final_waypoints"/>
     <!-- Pure Pursuit Node -->
-    <include file="$(find pure_pursuit)/launch/pure_pursuit.launch">
-        <arg name="is_linear_interpolation" value="True"/>
-        <arg name="publishes_for_steering_robot" value="True"/>
-    </include>
+    <group>
+        <remap from="vehicle_info/wheel_base" to="/vehicle_wheel_base"/>
+        <include file="$(find pure_pursuit)/launch/pure_pursuit.launch">
+            <arg name="is_linear_interpolation" value="True"/>
+            <arg name="publishes_for_steering_robot" value="True"/>
+        </include>
+    </group>
     <!-- Pure Pursuit Wrapper Node -->
     <node pkg="pure_pursuit_wrapper" type="pure_pursuit_wrapper_node" name="pure_pursuit_wrapper_node" output="screen">
         <rosparam command="load" file="$(find pure_pursuit_wrapper)/config/default.yaml" />


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
The pure pursuit node has a parameter which is not exposed by the launch file that is used to configure the wheel base of the vehicle. It is pointed at a non-private parameter, which does not match what carma expects. This PR adds a parameter remapping to correct this issue. 

To verify this change. Try running carma in the pacifica without the change, then try running in the pacifica with the change. You should see improved waypoint following performance. 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#333
#500 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Make CARMA waypoint following perform similar to autoware. 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the red truck this change improved waypoint following performance. 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
