### PR TITLE
updated rviz to include lanelet2 vizualization

### DIFF
--- a/carmajava/rviz/carma_default.rviz
+++ b/carmajava/rviz/carma_default.rviz
@@ -178,6 +178,7 @@ Visualization Manager:
       Unreliable: false
       Value: false
       Visibility:
+        "": true
         A* Sim Obstacle: true
         Behavior State: true
         Control Pose: true
@@ -233,7 +234,7 @@ Visualization Manager:
       Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
-      Max Intensity: 247
+      Max Intensity: 243
       Min Color: 0; 0; 0
       Min Intensity: 0
       Name: Points Raw
@@ -746,6 +747,18 @@ Visualization Manager:
         {}
       Queue Size: 100
       Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /environment/lanelet2_map_viz
+      Name: LaneLet2 Map
+      Namespaces:
+        center_lane_line: true
+        crosswalk_lanelets: true
+        lanelet direction: true
+        left_lane_bound: true
+        right_lane_bound: true
+      Queue Size: 100
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -780,11 +793,11 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.00999999978
-      Scale: 10
+      Scale: 5.25011683
       Target Frame: base_link
       Value: TopDownOrtho (rviz)
-      X: -0.0867699087
-      Y: 0.400452256
+      X: -175.891754
+      Y: 141.111282
     Saved: ~
 Window Geometry:
   Camera:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The RVIZ profile needs to be updated to add the marker for the lanelet2 to display the vector map lanes. 

After this has been merged, please manually update the /opt/carma/rviz/ to have this new profile and use it. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/CARMAPlatform/issues/517

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Urus Release and need to update the /opt/carma/rviz with this new profile. 

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
On blue lexus. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
