### PR TITLE
Resolve issue with lane change detection after lanelet2 updates

### DIFF
--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -412,7 +412,8 @@ void CARMAWorldModel::computeDowntrackReferenceLine()
       auto nextLanelet = shortest_path[next_index];
       lanelet::LineString3d nextCenterline = copyConstructLineString(nextLanelet.centerline());
 
-      size_t connectionCount = shortest_path_graph->possiblePaths(ll, 1, false).size();
+      size_t connectionCount = shortest_path_graph->possiblePaths(ll, (uint32_t) 2, false).size();
+
       if (connectionCount == 1)
       {  // Get list of connected lanelets without lanechanges. On the shortest path this should only return 1 or 0
         // No lane change


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

After pulling in the newest updates for lanelet2 the carma_wm unit tests for computing crosstrack downtrack were broken. It appears that this is because the api for the possiblePaths function of the routing graph has changed slightly. This is used to detect lanechanges in the route by carma_wm. Updating this call to assume possible paths always include the starting lanelet seems to resolve this issue. 
Lanelet2 Update PR
usdot-fhwa-stol/autoware.ai#48
## Related Issue

#547

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit tests pass locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
