### PR TITLE
Log error on spaces in route name

### DIFF
--- a/route_generator/CMakeLists.txt
+++ b/route_generator/CMakeLists.txt
@@ -88,5 +88,8 @@ install(DIRECTORY launch
 #############
 ## Testing ##
 #############
-catkin_add_gmock(${PROJECT_NAME}-test test/test_route_generator.cpp)
+catkin_add_gmock(${PROJECT_NAME}-test 
+  test/test_route_generator.cpp
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
+)
 target_link_libraries(${PROJECT_NAME}-test route_generator_library ${catkin_LIBRARIES})

--- a/route_generator/src/route_generator.cpp
+++ b/route_generator/src/route_generator.cpp
@@ -59,7 +59,18 @@ bool RouteGenerator::set_active_route_cb(cav_srvs::SetActiveRouteRequest &req, c
 {
     if(!route_is_active_)
     {
-        std::string route_file_name = req.routeID.append(".csv");
+        std::string route_file_name = req.routeID;
+
+        // Check if the route file name contains spaces and if so log an error as waypoint_loader does not support spaces in file names
+        // TODO once the waypoint_loader is no longer required it may be possible to support files with spaces
+        if (route_file_name.find(" ") != std::string::npos) {
+            ROS_WARN_STREAM("Route file name cannot contain spaces");
+            resp.errorStatus = cav_srvs::SetActiveRouteResponse::NO_ROUTE;
+            return true;
+        }
+
+        route_file_name = route_file_name + ".csv";
+
         std_msgs::String selected_route_file_path;
         selected_route_file_path.data = route_file_path_ + route_file_name;
         route_file_path_pub_.publish(selected_route_file_path);

--- a/route_generator/test/test_route_generator.cpp
+++ b/route_generator/test/test_route_generator.cpp
@@ -20,8 +20,9 @@
 
 TEST(RouteGeneratorTest, testReadFileFunction)
 {
-    std::vector<std::string> file_names = RouteGenerator::read_route_names("/home/qswawrq/CARMAWorkspace/src/route_generator/resource/");
-    for(int i = 0; i < file_names.size(); ++i)
+    std::vector<std::string> file_names = RouteGenerator::read_route_names("../resource/");
+    sort(file_names.begin(),file_names.end()); // Ensure names are in alphabetical order
+    for(size_t i = 0; i < file_names.size(); ++i)
     {
         std::string expect_file_name = "route" + std::to_string(i + 1) + ".csv";
         EXPECT_EQ(file_names[i], expect_file_name);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
As mentioned in #549 the waypoint_loader does not work with files containing spaces in their file name. This PR adds a log statement to warn the user of this to prevent silent failure. 
Helps make the resolution of #407 more robust

Additionally, it fixes a file path in route generator unit tests that prevented them be run on any machine. 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Prevent silent failure of route loading
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On local VM
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
