### PR TITLE
Add get traffic rules to world model

### DIFF
--- a/carma_wm/CMakeLists.txt
+++ b/carma_wm/CMakeLists.txt
@@ -31,9 +31,9 @@ find_package(Eigen3 REQUIRED)
 ## Catkin export configuration
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES carma_wm
+  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS ${PKG_CATKIN_DEPS}
-  DEPENDS Boost Eigen3
+  DEPENDS Boost EIGEN3
 )
 
 ###########

--- a/carma_wm/include/carma_wm/WorldModel.h
+++ b/carma_wm/include/carma_wm/WorldModel.h
@@ -25,6 +25,8 @@
 #include <lanelet2_core/primitives/Point.h>
 #include <lanelet2_routing/Route.h>
 #include <lanelet2_routing/RoutingGraph.h>
+#include <lanelet2_traffic_rules/TrafficRules.h>
+#include <lanelet2_core/utility/Optional.h>
 
 namespace carma_wm
 {
@@ -38,6 +40,9 @@ using LaneletRoutingGraphPtr = std::shared_ptr<lanelet::routing::RoutingGraph>;
 using LaneletRoutingGraphConstPtr = std::shared_ptr<const lanelet::routing::RoutingGraph>;
 using LaneletRoutingGraphUPtr = std::unique_ptr<lanelet::routing::RoutingGraph>;
 using LaneletRoutingGraphConstUPtr = std::unique_ptr<const lanelet::routing::RoutingGraph>;
+
+using TrafficRulesConstPtr = std::shared_ptr<const lanelet::traffic_rules::TrafficRules>;
+using TrafficRulesUConstPtr = std::unique_ptr<const lanelet::traffic_rules::TrafficRules>;
 
 /*! \brief Position in a track based coordinate system where the axis are downtrack and crosstrack.
  *         Positive crosstrack is to the left of the reference line
@@ -113,8 +118,9 @@ public:
   /*! \brief Returns a pair of TrackPos, computed in 2d, of the provided area relative to the current route.
    *        The distance is based on the Area vertex with the smallest and largest downtrack distance
    *        This method overload is the most expensive of the routeTrackPos methods
-   * 
-   * NOTE: The route definition used in this class contains discontinuities in the reference line at lane changes. It is important to consider that when using route related functions. 
+   *
+   * NOTE: The route definition used in this class contains discontinuities in the reference line at lane changes. It is
+   * important to consider that when using route related functions.
    *
    * \param area The lanelet2 area which will have its distance computed
    *
@@ -127,8 +133,9 @@ public:
 
   /*! \brief Returns the TrackPos, computed in 2d, of the provided lanelet relative to the current route.
    *        The distance is based on the first point in the lanelet centerline
-   * 
-   * NOTE: The route definition used in this class contains discontinuities in the reference line at lane changes. It is important to consider that when using route related functions. 
+   *
+   * NOTE: The route definition used in this class contains discontinuities in the reference line at lane changes. It is
+   * important to consider that when using route related functions.
    *
    * \param lanelet The lanelet2 lanelet which will have its distance computed
    *
@@ -140,7 +147,8 @@ public:
 
   /*! \brief Returns the TrackPos, computed in 2d, of the provided point relative to the current route
    *
-   * NOTE: The route definition used in this class contains discontinuities in the reference line at lane changes. It is important to consider that when using route related functions. 
+   * NOTE: The route definition used in this class contains discontinuities in the reference line at lane changes. It is
+   * important to consider that when using route related functions.
    *
    * \param point The lanelet2 point which will have its distance computed
    *
@@ -256,6 +264,17 @@ public:
    * loaded
    */
   virtual LaneletRoutingGraphConstPtr getMapRoutingGraph() const = 0;
+
+  /*! \brief Get a pointer to the traffic rules object used internally by the world model and considered the carma
+   * system default
+   *
+   * \param participant The lanelet participant to return the traffic rules object for. Defaults to a generic vehicle
+   *
+   * \return Optional Shared pointer to an intialized traffic rules object which is used by carma. Optional is false if
+   * no rule set is available for the requested participant.
+   */
+  virtual lanelet::Optional<TrafficRulesConstPtr>
+  getTrafficRules(const std::string& participant = lanelet::Participants::Vehicle) const = 0;
 
   /*! \brief Function for computing curvature from 3 points.
    *

--- a/carma_wm/src/CARMAWorldModel.cpp
+++ b/carma_wm/src/CARMAWorldModel.cpp
@@ -26,7 +26,7 @@
 #include <Eigen/Core>
 #include <Eigen/LU>
 #include <cmath>
-#include <carma_wm/lanelet/CarmaUSTrafficRules.h>
+#include <lanelet2_extension/traffic_rules/CarmaUSTrafficRules.h>
 
 namespace carma_wm
 {

--- a/carma_wm/src/CARMAWorldModel.h
+++ b/carma_wm/src/CARMAWorldModel.h
@@ -27,9 +27,9 @@ namespace carma_wm
  *
  *  Proper usage of this class dictates that the Map and Route object be kept in sync
  *
- * NOTE: This class relies on some lanelet::routing::RoutingGraph objects these have to be initialized using
- * TrafficRules which by default are only defined for Germany. The default traffic participant used is a car. Changing
- * this is a TODO:
+ * NOTE: This class uses the CarmaUSTrafficRules class internally to interpret routes.
+ *       So routes which are set on this model should use the getTrafficRules() method to build using the correct rule
+ * set
  */
 class CARMAWorldModel : public WorldModel
 {
@@ -90,6 +90,9 @@ public:
                           const lanelet::BasicPoint2d& p3) const override;
 
   double getAngleBetweenVectors(const Eigen::Vector2d& vec1, const Eigen::Vector2d& vec2) const override;
+
+  lanelet::Optional<TrafficRulesConstPtr>
+  getTrafficRules(const std::string& participant = lanelet::Participants::Vehicle) const override;
 
 private:
   /*! \brief Helper function to compute the geometry of the route downtrack/crosstrack reference line

--- a/carma_wm/test/CARMAWorldModleTest.cpp
+++ b/carma_wm/test/CARMAWorldModleTest.cpp
@@ -841,4 +841,35 @@ TEST(CARMAWorldModelTest, getLaneletsBetween)
   ASSERT_EQ(1, result.size());
   ASSERT_NEAR(result[0].id(), (cmw.getRoute()->shortestPath().begin() + 1)->id(), 0.000001);
 }
+
+TEST(CARMAWorldModelTest, getTrafficRules)
+{
+  CARMAWorldModel cmw;
+
+  ///// Test straight route
+  addStraightRoute(cmw);
+
+  auto default_participant = cmw.getTrafficRules();
+  ASSERT_TRUE(!!default_participant);  // Verify traffic rules object was returned
+  ASSERT_EQ(lanelet::Participants::Vehicle, (*default_participant)->participant());
+
+  default_participant = cmw.getTrafficRules(lanelet::Participants::VehicleCar);
+  ASSERT_TRUE(!!default_participant);
+  ASSERT_EQ(lanelet::Participants::VehicleCar, (*default_participant)->participant());
+
+  default_participant = cmw.getTrafficRules(lanelet::Participants::VehicleTruck);
+  ASSERT_TRUE(!!default_participant);
+  ASSERT_EQ(lanelet::Participants::VehicleTruck, (*default_participant)->participant());
+
+  default_participant = cmw.getTrafficRules(lanelet::Participants::Pedestrian);
+  ASSERT_TRUE(!!default_participant);
+  ASSERT_EQ(lanelet::Participants::Pedestrian, (*default_participant)->participant());
+
+  default_participant = cmw.getTrafficRules(lanelet::Participants::Bicycle);
+  ASSERT_TRUE(!!default_participant);
+  ASSERT_EQ(lanelet::Participants::Bicycle, (*default_participant)->participant());
+
+  default_participant = cmw.getTrafficRules("fake_person");
+  ASSERT_FALSE(!!default_participant);
+}
 }  // namespace carma_wm


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This adds a get traffic rules function to the world model which will return a CARMATrafficRules object. This is a port of functionality added in this closed PR #570 which apparently never made it back into the repo. 
<!--- Describe your changes in detail -->

## Related Issue
#441
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
