### PR TITLE
Health

### DIFF
--- a/health_monitor/include/driver_manager.h
+++ b/health_monitor/include/driver_manager.h
@@ -1,5 +1,4 @@
 #pragma once
-
 /*
  * Copyright (C) 2019-2020 LEIDOS.
  *
@@ -17,7 +16,9 @@
  */
 
 #include <cav_msgs/DriverStatus.h>
+#include <cav_msgs/SystemAlert.h>
 #include "entry_manager.h"
+#include <iostream>
 
 namespace health_monitor
 {
@@ -29,30 +30,36 @@ namespace health_monitor
              * \brief Default constructor for DriverManager
              */
             DriverManager();
-            
             /*!
              * \brief Constructor for DriverManager takes in crtitical driver names and driver timeout
              */
-            DriverManager(std::vector<std::string> critical_driver_names, const long driver_timeout);
-
+            DriverManager(std::vector<std::string> critical_driver_names, const long driver_timeout,std::vector<std::string> lidar_gps_driver_names);
             /*!
              * \brief Update driver status
              */
             void update_driver_status(const cav_msgs::DriverStatusConstPtr& msg, long current_time);
-
             /*!
-             * \brief Check if all critical drivers are operational
+             * \brief Check if all critical drivers are operational for truck
              */
-            bool are_critical_drivers_operational(long current_time);
-
+            std::string are_critical_drivers_operational_truck(long current_time);
+            /*!
+             * \brief Check if all critical drivers are operational for car
+             */
+            std::string are_critical_drivers_operational_car(long current_time);
+            /*!
+             * \brief Evaluate if the sensor is available
+             */
+            void evaluate_sensor(int &sensor_input,bool available,long current_time,long timestamp,long driver_timeout);
+            /*!
+             * \brief Handle the spin and publisher
+             */
+            cav_msgs::SystemAlert handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long startup_duration,bool is_zero);
 
         private:
 
             EntryManager em_;
             // timeout for critical driver timeout
             long driver_timeout_;
-            // number of critical drivers
-            int critical_driver_number_;
 
     };
 }

--- a/health_monitor/include/driver_manager.h
+++ b/health_monitor/include/driver_manager.h
@@ -53,7 +53,7 @@ namespace health_monitor
             /*!
              * \brief Handle the spin and publisher
              */
-            cav_msgs::SystemAlert handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long startup_duration,long int is_zero);
+            cav_msgs::SystemAlert handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long startup_duration,bool is_zero);
 
         private:
 

--- a/health_monitor/include/driver_manager.h
+++ b/health_monitor/include/driver_manager.h
@@ -53,7 +53,7 @@ namespace health_monitor
             /*!
              * \brief Handle the spin and publisher
              */
-            cav_msgs::SystemAlert handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long startup_duration,bool is_zero);
+            cav_msgs::SystemAlert handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long startup_duration,long int is_zero);
 
         private:
 

--- a/health_monitor/include/entry_manager.h
+++ b/health_monitor/include/entry_manager.h
@@ -30,11 +30,15 @@ namespace health_monitor
              * \brief Default constructor for EntryManager.
              */
             EntryManager();
-
             /*!
              * \brief Constructor for EntryManager to set required entries.
              */
             EntryManager(std::vector<std::string> required_entries);
+
+            /*!
+             * \brief Constructor for EntryManager to set required entries and lidar gps entires.
+             */
+            EntryManager(std::vector<std::string> required_entries,std::vector<std::string> lidar_gps_entries); 
 
             /*!
              * \brief Add a new entry if the given name does not exist.
@@ -61,6 +65,10 @@ namespace health_monitor
              * \brief Check if the entry is required
              */
             bool is_entry_required(const std::string name) const;
+            /*!
+             * \brief Check if the entry is required
+             */
+           int is_lidar_gps_entry_required(const std::string &name) const;
 
         private:
 
@@ -69,5 +77,8 @@ namespace health_monitor
 
             // list of required entries
             std::vector<std::string> required_entries_;
+
+            // list of lidar and gps entries 
+            std::vector<std::string> lidar_gps_entries_; 
     };
 }

--- a/health_monitor/include/health_monitor.h
+++ b/health_monitor/include/health_monitor.h
@@ -82,6 +82,8 @@ namespace health_monitor
             std::string plugin_service_prefix_;
             std::string strategic_plugin_service_suffix_;
             std::string tactical_plugin_service_suffix_;
+            ros::Time start_time_flag_; //Bool for start up time
+
 
             // spin callback function
             bool spin_cb();

--- a/health_monitor/include/health_monitor.h
+++ b/health_monitor/include/health_monitor.h
@@ -70,10 +70,13 @@ namespace health_monitor
             // ROS params
             double spin_rate_, driver_timeout_, startup_duration_;
             std::vector<std::string> required_drivers_;
+            std::vector<std::string> lidar_gps_drivers_; 
             std::vector<std::string> required_plugins_;
+            bool truck_;
+            bool car_;
 
             // record of startup timestamp
-            ros::Time start_up_timestamp_;
+            long start_up_timestamp_;
 
             // service name prefix and suffix
             std::string plugin_service_prefix_;

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -173,7 +173,7 @@ namespace health_monitor
 
     }
     
-    cav_msgs::SystemAlert DriverManager::handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long start_duration,long int is_zero)
+    cav_msgs::SystemAlert DriverManager::handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long start_duration,bool is_zero)
     {
          cav_msgs::SystemAlert alert;
 

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -173,7 +173,7 @@ namespace health_monitor
 
     }
     
-    cav_msgs::SystemAlert DriverManager::handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long start_duration,bool is_zero)
+    cav_msgs::SystemAlert DriverManager::handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long start_duration,long int is_zero)
     {
          cav_msgs::SystemAlert alert;
 

--- a/health_monitor/src/driver_manager.cpp
+++ b/health_monitor/src/driver_manager.cpp
@@ -18,51 +18,270 @@
 
 namespace health_monitor
 {
-    
+
     DriverManager::DriverManager() : driver_timeout_(1000) {}
-    
-    DriverManager::DriverManager(std::vector<std::string> critical_driver_names, const long driver_timeout)
+
+    DriverManager::DriverManager(std::vector<std::string> critical_driver_names, const long driver_timeout, std::vector<std::string> lidar_gps_driver_names) 
     {
-        em_ = EntryManager(critical_driver_names);
+        em_ = EntryManager(critical_driver_names,lidar_gps_driver_names);
         driver_timeout_ = driver_timeout;
-        critical_driver_number_ = critical_driver_names.size();
     }
 
 
     void DriverManager::update_driver_status(const cav_msgs::DriverStatusConstPtr& msg, long current_time)
     {
         // Params: bool available, bool active, std::string name, long timestamp, uint8_t type
-        Entry driver_status(msg->status == cav_msgs::DriverStatus::OPERATIONAL || msg->status == cav_msgs::DriverStatus::DEGRADED,
-                            true, msg->name, current_time, 0, "");
+        Entry driver_status(msg->status == cav_msgs::DriverStatus::OPERATIONAL || msg->status == cav_msgs::DriverStatus::DEGRADED,true, msg->name, current_time, 0, "");
         em_.update_entry(driver_status);
     }
 
-    bool DriverManager::are_critical_drivers_operational(long current_time)
+    void DriverManager::evaluate_sensor(int &sensor_input,bool available,long current_time,long timestamp,long driver_timeout)
     {
-        int critical_driver_counter = 0;
-        std::vector<Entry> driver_list = em_.get_entries();
+        if((!available) || (current_time-timestamp > driver_timeout))
+           {
+            sensor_input=0;
+           }
+           else
+           {
+            sensor_input=1;
+           }
+    }
+
+    std::string DriverManager::are_critical_drivers_operational_truck(long current_time)
+    {
+        int ssc=0;
+        int lidar1=0;
+        int lidar2=0;
+        int gps=0;
+        std::vector<Entry> driver_list = em_.get_entries(); //Real time driver list from driver status
         for(auto i = driver_list.begin(); i < driver_list.end(); ++i)
         {
             if(em_.is_entry_required(i->name_))
             {
-                // if a required driver is not optional or has been timeout
-                if((!i->available_) || (current_time - i->timestamp_ > driver_timeout_))
-                {
-                    // TODO: return the name of the non-functional driver for easy debugging
-                    return false;
-                } else
-                {
-                    ++critical_driver_counter;
-                }
-                
+              evaluate_sensor(ssc,i->available_,current_time,i->timestamp_,driver_timeout_);
+            }
+
+            if(em_.is_lidar_gps_entry_required(i->name_)==0) //Lidar1
+            {
+               evaluate_sensor(lidar1,i->available_,current_time,i->timestamp_,driver_timeout_);
+            }
+            else if(em_.is_lidar_gps_entry_required(i->name_)==1) //Lidar2
+            {
+              evaluate_sensor(lidar2,i->available_,current_time,i->timestamp_,driver_timeout_);
+            }
+            else if(em_.is_lidar_gps_entry_required(i->name_)==2) //GPS
+            {
+              evaluate_sensor(gps,i->available_,current_time,i->timestamp_,driver_timeout_);
             }
         }
-        // all criticial driver in the driver_list are operational, but the number of critical driver does not match the desired number
-        if(critical_driver_counter != critical_driver_number_)
+
+       //Decision making 
+
+        if(ssc==1)
         {
-            return false;
+
+            if((lidar1==0) && (lidar2==0) && (gps==0))
+            {
+                return "s_1_l1_0_l2_0_g_0";
+            }
+            else if((lidar1==0) && (lidar2==0) && (gps==1))
+            {
+                return "s_1_l1_0_l2_0_g_1";
+            }
+            else if((lidar1==0) && (lidar2==1) && (gps==0))
+            {
+                return "s_1_l1_0_l2_1_g_0";
+            }
+            else if((lidar1==0) && (lidar2==1) && (gps==1))
+            {
+                return "s_1_l1_0_l2_1_g_1";
+            }
+            else if((lidar1==1) && (lidar2==0) && (gps==0))
+            {
+                return "s_1_l1_1_l2_0_g_0";
+            }
+            else if((lidar1==1) && (lidar2==0) && (gps==1))
+            {
+                return "s_1_l1_1_l2_0_g_1";
+            }
+            else if((lidar1==1) && (lidar2==1) && (gps==0))
+            {
+                return "s_1_l1_1_l2_1_g_0";
+            }
+            else if((lidar1==1) && (lidar2==1) && (gps==1))
+            {
+                return "s_1_l1_1_l2_1_g_1";
+            }
         }
-        return true;
+        else
+        {
+
+            return "s_0";
+        }
+
+    }
+
+
+    std::string DriverManager::are_critical_drivers_operational_car(long current_time)
+    {
+        int ssc=0;
+        int lidar=0;
+        int gps=0;
+        std::vector<Entry> driver_list = em_.get_entries(); //Real time driver list from driver status
+        for(auto i = driver_list.begin(); i < driver_list.end(); ++i)
+        {
+            if(em_.is_entry_required(i->name_))
+            {
+                evaluate_sensor(ssc,i->available_,current_time,i->timestamp_,driver_timeout_);
+            }
+
+            if(em_.is_lidar_gps_entry_required(i->name_)==0) //Lidar
+            {
+                evaluate_sensor(lidar,i->available_,current_time,i->timestamp_,driver_timeout_);
+            }
+            else if(em_.is_lidar_gps_entry_required(i->name_)==1) //GPS
+            {
+                evaluate_sensor(gps,i->available_,current_time,i->timestamp_,driver_timeout_);
+            }
+        }
+
+        //Decision making 
+
+        if(ssc==1)
+        {
+            if((lidar==0) && (gps==0))
+            {
+                return "s_1_l_0_g_0";
+            }
+            else if((lidar==0) && (gps==1))
+            {
+                return "s_1_l_0_g_1";
+            }
+            else if((lidar==1) && (gps==0))
+            {
+                return "s_1_l_1_g_0";
+            }
+            else if((lidar==1) && (gps==1))
+            {
+                return "s_1_l_1_g_1";
+            }
+        }
+        else
+        {
+            return "s_0";
+        }
+
+    }
+    
+    cav_msgs::SystemAlert DriverManager::handleSpin(bool truck,bool car,long time_now,long start_up_timestamp,long start_duration,bool is_zero)
+    {
+         cav_msgs::SystemAlert alert;
+
+         if(truck==true)
+        {
+            if(are_critical_drivers_operational_truck(time_now)=="s_1_l1_1_l2_1_g_1")
+            {
+                alert.description = "All enssential drivers are ready(SSC,LIDAR1,LIDAR2 and GPS)";
+                alert.type = cav_msgs::SystemAlert::DRIVERS_READY;
+                return alert;
+            } 
+           else if(is_zero || time_now - start_up_timestamp <= start_duration)
+            {
+                alert.description = "System is starting up...";
+                alert.type = cav_msgs::SystemAlert::NOT_READY;
+                return alert;
+            }
+            else if((are_critical_drivers_operational_truck(time_now)=="s_1_l1_0_l2_1_g_1") || (are_critical_drivers_operational_truck(time_now)=="s_1_l1_1_l2_0_g_1"))
+            {
+            
+                alert.description = "Only one LIDAR, GPS and SSC is currently working";
+                alert.type = cav_msgs::SystemAlert::CAUTION;
+                return alert;
+            }
+            else if((are_critical_drivers_operational_truck(time_now)=="s_1_l1_0_l2_1_g_0") || (are_critical_drivers_operational_truck(time_now)=="s_1_l1_1_l2_0_g_0"))
+            {   
+                alert.description = "GPS stopped running but one LIDAR and SSC is still working";
+                alert.type = cav_msgs::SystemAlert::CAUTION;
+                return alert;
+            }
+            else if(are_critical_drivers_operational_truck(time_now)=="s_1_l1_0_l2_0_g_1")
+            {
+                alert.description = "Both LIDARS are not running but GPS and SSC is still working";
+                alert.type = cav_msgs::SystemAlert::WARNING;
+                return alert;
+            }
+            else if(are_critical_drivers_operational_truck(time_now)=="s_1_l1_0_l2_0_g_0")
+            {
+                alert.description = "All LIDARS and GPS stopped running, but SSC is working";
+                alert.type = cav_msgs::SystemAlert::FATAL;
+                return alert;
+            }
+            else if(are_critical_drivers_operational_truck(time_now)=="s_0")
+            {
+                alert.description = "SSC stopped working";
+                alert.type = cav_msgs::SystemAlert::FATAL;
+                return alert;
+            }
+            else
+            {
+                alert.description = "UNKNOWN";
+                alert.type = cav_msgs::SystemAlert::FATAL;
+                return alert;  
+            }
+ 
+        }
+        else if(car==true)
+        {
+            if(are_critical_drivers_operational_car(time_now)=="s_1_l_1_g_1")
+            {
+                alert.description = "All enssential drivers are ready(SSC,LIDAR and GPS)";
+                alert.type = cav_msgs::SystemAlert::DRIVERS_READY;
+                return alert; 
+            }
+            else if(is_zero || time_now - start_up_timestamp <= start_duration)
+            {
+                alert.description = "System is starting up...";
+                alert.type = cav_msgs::SystemAlert::NOT_READY;
+                return alert; 
+            } 
+            else if(are_critical_drivers_operational_car(time_now)=="s_1_l_1_g_0")
+            {
+                alert.description = "GPS stopped working but SSC and LIDAR  is still running";
+                alert.type = cav_msgs::SystemAlert::CAUTION;
+                return alert; 
+            }
+            else if(are_critical_drivers_operational_car(time_now)=="s_1_l_0_g_1")
+            {
+                alert.description = "LIDAR stopped working but SSC and GPS is still running";
+                alert.type = cav_msgs::SystemAlert::WARNING;
+                return alert; 
+            }
+            else if(are_critical_drivers_operational_car(time_now)=="s_1_l_0_g_0")
+            {
+                alert.description = "LIDAR, GPS stopped working but SSC is still running";
+                alert.type = cav_msgs::SystemAlert::FATAL;
+                return alert; 
+            }
+            else if(are_critical_drivers_operational_car(time_now)=="s_0")
+            {
+                alert.description = "SSC stopped working";
+                alert.type = cav_msgs::SystemAlert::FATAL;
+                return alert; 
+            }
+            else
+            {
+                alert.description = "UNKNOWN";
+                alert.type = cav_msgs::SystemAlert::FATAL;
+                return alert;  
+            }
+        }
+        else
+        {
+            alert.description = "UNKNOWN";
+            alert.type = cav_msgs::SystemAlert::FATAL;
+            return alert; 
+        }
     }
 
 }
+

--- a/health_monitor/src/entry_manager.cpp
+++ b/health_monitor/src/entry_manager.cpp
@@ -21,11 +21,10 @@ namespace health_monitor
 {
 
     EntryManager::EntryManager() {}
+
+    EntryManager::EntryManager(std::vector<std::string> required_entries):required_entries_(required_entries) {} 
     
-    EntryManager::EntryManager(std::vector<std::string> required_entries)
-    {
-        this->required_entries_ = required_entries;
-    }
+    EntryManager::EntryManager(std::vector<std::string> required_entries,std::vector<std::string> lidar_gps_entries) :required_entries_(required_entries),lidar_gps_entries_(lidar_gps_entries){}
 
     void EntryManager::update_entry(Entry entry)
     {
@@ -84,6 +83,19 @@ namespace health_monitor
             }
         }
         return false;
+    }
+
+    int EntryManager::is_lidar_gps_entry_required(const std::string &name) const
+    {
+        
+        for(int i=0;i<lidar_gps_entries_.size();i++)
+        {
+            if(lidar_gps_entries_[i]==name)
+            {
+                return i;
+            }
+
+        }
     }
 
 }

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -103,7 +103,7 @@ namespace health_monitor
         long time_now=(ros::Time::now().toNSec() / 1e6);
         ros::Duration sd(startup_duration_);
         long start_duration=sd.toNSec() / 1e6;
-        bool is_zero=start_up_timestamp_.isZero();
+        long int is_zero=start_up_timestamp_.isZero();
        // nh_.publishSystemAlert(driver_manager_.handleSpin(truck_,car_,start_up_timestamp_,startup_duration_));
         nh_.publishSystemAlert(driver_manager_.handleSpin(truck_,car_,time_now,start_up_timestamp_,start_duration,is_zero));
         return true;

--- a/health_monitor/src/health_monitor.cpp
+++ b/health_monitor/src/health_monitor.cpp
@@ -56,6 +56,7 @@ namespace health_monitor
 
         // record starup time
         start_up_timestamp_ = ros::Time::now().toNSec() / 1e6;
+        start_time_flag_=ros::Time::now();
     }
     
     void HealthMonitor::run()
@@ -103,9 +104,8 @@ namespace health_monitor
         long time_now=(ros::Time::now().toNSec() / 1e6);
         ros::Duration sd(startup_duration_);
         long start_duration=sd.toNSec() / 1e6;
-        long int is_zero=start_up_timestamp_.isZero();
-       // nh_.publishSystemAlert(driver_manager_.handleSpin(truck_,car_,start_up_timestamp_,startup_duration_));
-        nh_.publishSystemAlert(driver_manager_.handleSpin(truck_,car_,time_now,start_up_timestamp_,start_duration,is_zero));
+
+        nh_.publishSystemAlert(driver_manager_.handleSpin(truck_,car_,time_now,start_up_timestamp_,start_duration,start_time_flag_.isZero()));
         return true;
     }
 

--- a/health_monitor/test/test_driver_manager.cpp
+++ b/health_monitor/test/test_driver_manager.cpp
@@ -19,100 +19,1349 @@
 
 namespace health_monitor
 {
-    
-    TEST(DriverManagerTest, testNormalDriverStatus)
+
+//////////////////// Unit test for car part///////////////////////////////////////////////
+
+    TEST(DriverManagerTest, testCarNormalDriverStatus)
     {
-        std::vector<std::string> required_drivers{"controller", "lidar"};
-        DriverManager dm(required_drivers, 1000L);
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
         cav_msgs::DriverStatus msg1;
         msg1.controller = true;
         msg1.name = "controller";
         msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
         cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
         dm.update_driver_status(msg1_pointer, 1000);
+        
         cav_msgs::DriverStatus msg2;
         msg2.lidar = true;
         msg2.name = "lidar";
         msg2.status = cav_msgs::DriverStatus::DEGRADED;
         cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
         dm.update_driver_status(msg2_pointer, 1000);
-        EXPECT_EQ(true, dm.are_critical_drivers_operational(1500));
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        EXPECT_EQ("s_1_l_1_g_1", dm.are_critical_drivers_operational_car(1500));
     }
 
-    TEST(DriverManagerTest, testDriverStatusTimeout)
+    TEST(DriverManagerTest, testCarSsc_1_Lidar_0_Gps_0)
     {
-        std::vector<std::string> required_drivers{"controller", "lidar"};
-        DriverManager dm(required_drivers, 1000L);
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
         cav_msgs::DriverStatus msg1;
         msg1.controller = true;
         msg1.name = "controller";
         msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
         cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
         dm.update_driver_status(msg1_pointer, 1000);
-        cav_msgs::DriverStatus msg2;
-        msg2.lidar = true;
-        msg2.name = "lidar";
-        msg2.status = cav_msgs::DriverStatus::DEGRADED;
-        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
-        dm.update_driver_status(msg2_pointer, 1000);
-        EXPECT_EQ(false, dm.are_critical_drivers_operational(2001));
-    }
-
-    TEST(DriverManagerTest, testErrorDriverStatus1)
-    {
-        std::vector<std::string> required_drivers{"controller", "lidar"};
-        DriverManager dm(required_drivers, 1000L);
-        cav_msgs::DriverStatus msg1;
-        msg1.controller = true;
-        msg1.name = "controller";
-        msg1.status = cav_msgs::DriverStatus::FAULT;
-        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
-        dm.update_driver_status(msg1_pointer, 1000);
-        cav_msgs::DriverStatus msg2;
-        msg2.lidar = true;
-        msg2.name = "lidar";
-        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
-        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
-        dm.update_driver_status(msg2_pointer, 1000);
-        EXPECT_EQ(false, dm.are_critical_drivers_operational(1500));
-    }
-
-    TEST(DriverManagerTest, testErrorDriverStatus2)
-    {
-        std::vector<std::string> required_drivers{"controller", "lidar"};
-        DriverManager dm(required_drivers, 1000L);
-        cav_msgs::DriverStatus msg1;
-        msg1.controller = true;
-        msg1.name = "controller";
-        msg1.status = cav_msgs::DriverStatus::OFF;
-        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
-        dm.update_driver_status(msg1_pointer, 1000);
+        
         cav_msgs::DriverStatus msg2;
         msg2.lidar = true;
         msg2.name = "lidar";
         msg2.status = cav_msgs::DriverStatus::OFF;
         cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
         dm.update_driver_status(msg2_pointer, 1000);
-        EXPECT_EQ(false, dm.are_critical_drivers_operational(1500));
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        EXPECT_EQ("s_1_l_0_g_0", dm.are_critical_drivers_operational_car(1500));
     }
 
-    TEST(DriverManagerTest, testMissingCriticalDriver)
+        TEST(DriverManagerTest, testCarSsc_0_Lidar_1_Gps_1)
     {
-        std::vector<std::string> required_drivers{"controller", "lidar"};
-        DriverManager dm(required_drivers, 1000L);
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        EXPECT_EQ("s_0", dm.are_critical_drivers_operational_car(1500));
+    }
+
+    TEST(DriverManagerTest, testCarSsc_1_Lidar_0_Gps_1)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
         cav_msgs::DriverStatus msg1;
         msg1.controller = true;
         msg1.name = "controller";
         msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
         cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
         dm.update_driver_status(msg1_pointer, 1000);
+        
         cav_msgs::DriverStatus msg2;
-        msg2.radar = true;
-        msg2.name = "radar";
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        EXPECT_EQ("s_1_l_0_g_1", dm.are_critical_drivers_operational_car(1500));
+    }
+
+    TEST(DriverManagerTest, testCarSsc_1_Lidar_1_Gps_0)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
         msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
         cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
         dm.update_driver_status(msg2_pointer, 1000);
-        EXPECT_EQ(false, dm.are_critical_drivers_operational(1500));
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        EXPECT_EQ("s_1_l_1_g_0", dm.are_critical_drivers_operational_car(1500));
+    }
+
+        TEST(DriverManagerTest, testCarErrorDriverStatusTimeOut)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        EXPECT_EQ("s_0", dm.are_critical_drivers_operational_car(2100));
+    }
+ //////////////////////////////////////////////////////////////////////////////////////////
+ 
+    TEST(DriverManagerTest, testCarHandleSpinDriversReady)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(5, alert.type);
+    }   
+
+    TEST(DriverManagerTest, testCarHandleSpinCautionGpsNotWorkingLidarWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(1, alert.type);
+    }   
+
+    TEST(DriverManagerTest, testCarHandleSpinWarningLidarNotWorkingGpsWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(2, alert.type);
+    }   
+
+    TEST(DriverManagerTest, testCarHandleSpinFatalLidarNotWorkingGpsNotWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(3, alert.type);
+    } 
+
+    TEST(DriverManagerTest, testCarHandleSpinFatalSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(3, alert.type);
+    } 
+
+    TEST(DriverManagerTest, testCarHandleSpinFatalUnknownInside)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(3, alert.type);
+    } 
+
+        TEST(DriverManagerTest, testCarHandleSpinNotReadyCase1)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,1000,750,1);
+
+        EXPECT_EQ(4, alert.type);
+    } 
+
+        TEST(DriverManagerTest, testCarHandleSpinNotReadyCase2)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=true;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,5000,750,0);
+
+        EXPECT_EQ(4, alert.type);
+    } 
+
+
+    TEST(DriverManagerTest, testCarTruckHandleSpinFatalUnknown)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.gnss = true;
+        msg3.name = "gps";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        bool truck=false;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(3, alert.type);
+    } 
+
+
+////////////////////////// Unit test for truck part////////////////////////////////////////
+    
+    TEST(DriverManagerTest, testTruckNormalDriverStatus)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_1_l2_1_g_1", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_0_Lidar1_1_Lidar2_1_Gps_1)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_0", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_1_Lidar1_0_Lidar2_0_Gps_0)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_0_l2_0_g_0", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_1_Lidar1_0_Lidar2_0_Gps_1)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_0_l2_0_g_1", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_1_Lidar1_0_Lidar2_1_Gps_0)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_0_l2_1_g_0", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_1_Lidar1_0_Lidar2_1_Gps_1)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_0_l2_1_g_1", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_1_Lidar1_1_Lidar2_0_Gps_0)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_1_l2_0_g_0", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_1_Lidar1_1_Lidar2_0_Gps_1)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_1_l2_0_g_1", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckSsc_1_Lidar1_1_Lidar2_1_Gps_0)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_1_l1_1_l2_1_g_0", dm.are_critical_drivers_operational_truck(1500));
+    }
+
+    TEST(DriverManagerTest, testTruckDriverStatusTimeout)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        EXPECT_EQ("s_0", dm.are_critical_drivers_operational_truck(2001));
+    }
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////    
+
+    TEST(DriverManagerTest, testHandleSpinDriverReady)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(5, alert.type);
+    }
+
+    TEST(DriverManagerTest, testHandleSpinCautionOneLidar1WorkingGpsWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(1, alert.type);
+    }
+
+    TEST(DriverManagerTest, testHandleSpinCautionOneLidar2WorkingGpsWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::DEGRADED;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(1, alert.type);
+    }
+
+        TEST(DriverManagerTest, testHandleSpinCautionOneLidar1WorkingGpsNotWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(1, alert.type);
+    }
+
+
+        TEST(DriverManagerTest, testHandleSpinCautionOneLidar2WorkingGpsNotWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(1, alert.type);
+    }
+
+    TEST(DriverManagerTest, testHandleSpinWarningLidarNotWorkingGpsWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(2, alert.type);
+    }
+
+    TEST(DriverManagerTest, testHandleSpinFatalLidarNotWorkingGpsNotWorkingSscWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(3, alert.type);
+    }
+
+    TEST(DriverManagerTest, testHandleSpinFatalSscNotWorking)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(3, alert.type);
+    }
+
+        TEST(DriverManagerTest, testHandleSpinFatalUnknownInsideTruck)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,150,750,0);
+
+        EXPECT_EQ(3, alert.type);
+    }
+
+
+    TEST(DriverManagerTest, testHandleSpinNotReadyCase1)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,1000,750,1);
+
+        EXPECT_EQ(4, alert.type);
+    }
+
+    TEST(DriverManagerTest, testHandleSpinNotReadyCase2)
+    {
+        std::vector<std::string> required_drivers{"controller"};
+        std::vector<std::string> lidar_gps_drivers{"lidar1", "lidar2","gps"};
+
+        DriverManager dm(required_drivers, 1000L,lidar_gps_drivers);
+
+        cav_msgs::DriverStatus msg1;
+        msg1.controller = true;
+        msg1.name = "controller";
+        msg1.status = cav_msgs::DriverStatus::OPERATIONAL;
+        cav_msgs::DriverStatusConstPtr msg1_pointer(new cav_msgs::DriverStatus(msg1));
+        dm.update_driver_status(msg1_pointer, 1000);
+        
+        cav_msgs::DriverStatus msg2;
+        msg2.lidar = true;
+        msg2.name = "lidar1";
+        msg2.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg2_pointer(new cav_msgs::DriverStatus(msg2));
+        dm.update_driver_status(msg2_pointer, 1000);
+
+        cav_msgs::DriverStatus msg3;
+        msg3.lidar = true;
+        msg3.name = "lidar2";
+        msg3.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg3_pointer(new cav_msgs::DriverStatus(msg3));
+        dm.update_driver_status(msg3_pointer, 1000);
+
+        cav_msgs::DriverStatus msg4;
+        msg4.gnss = true;
+        msg4.name = "gps";
+        msg4.status = cav_msgs::DriverStatus::OFF;
+        cav_msgs::DriverStatusConstPtr msg4_pointer(new cav_msgs::DriverStatus(msg4));
+        dm.update_driver_status(msg4_pointer, 1000);
+
+        bool truck=true;
+        bool car=false;
+        
+        cav_msgs::SystemAlert alert;
+        alert=dm.handleSpin(truck,car,1500,5000,750,0);
+
+        EXPECT_EQ(4, alert.type);
     }
 
 }

--- a/health_monitor/test/test_entry_manager.cpp
+++ b/health_monitor/test/test_entry_manager.cpp
@@ -118,4 +118,36 @@ namespace health_monitor
         EXPECT_EQ(false, em.is_entry_required("autoware_plugin_2"));
     }
 
+        TEST(EntryManagerTest, testTruckLidarGpsEntryCheck)
+    {   
+        std::vector<std::string> required_entries;
+        required_entries.push_back("ssc");
+ 
+        std::vector<std::string> lidar_gps_entries;
+        lidar_gps_entries.push_back("lidar1");
+        lidar_gps_entries.push_back("lidar2");
+        lidar_gps_entries.push_back("gps");
+
+        EntryManager em(required_entries,lidar_gps_entries);
+
+        EXPECT_EQ(0, em.is_lidar_gps_entry_required("lidar1"));
+        EXPECT_EQ(1, em.is_lidar_gps_entry_required("lidar2"));
+        EXPECT_EQ(2, em.is_lidar_gps_entry_required("gps"));
+    }
+
+        TEST(EntryManagerTest, testCarLidarGpsEntryCheck)
+    {   
+        std::vector<std::string> required_entries;
+        required_entries.push_back("ssc");
+ 
+        std::vector<std::string> lidar_gps_entries;
+        lidar_gps_entries.push_back("lidar");
+        lidar_gps_entries.push_back("gps");
+
+        EntryManager em(required_entries,lidar_gps_entries);
+
+        EXPECT_EQ(0, em.is_lidar_gps_entry_required("lidar"));
+        EXPECT_EQ(1, em.is_lidar_gps_entry_required("gps"));
+    }
+    
 }

--- a/health_monitor/test/test_plugin_manager.cpp
+++ b/health_monitor/test/test_plugin_manager.cpp
@@ -18,8 +18,7 @@
 #include <gtest/gtest.h>
 
 namespace health_monitor
-{
-    
+{    
     TEST(PluginManagerTest, testRegisteredPlugins)
     {
         std::vector<std::string> required_plugins{"autoware", "pure_pursuit"};


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
As a Carma vehicle operator, I need to have confidence that when a hardware element (e.g. sensor) fails, the software adequately handles the situation by falling back to other sensors or letting me know that I need to take over control of the vehicle.

The health monitor should be revisited to ensure adequate handling of component faults. In particular, regarding lidar, it should
a) if in a vehicle with multiple lidars, it should only issue a CAUTION if one of them fails, as long as at least one is still operating;
b) if all available lidars have failed, it should issue a WARNING, as long as GPS is still functional;
c) only if all lidars and the GPS has failed should it issue a FATAL alert.

Each alert should include a brief textual indication of the problem, constructed in a way that the UI can easily deconstruct in order to inform the user of the situation.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Tested
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
