### PR TITLE
Feature/ui information

### DIFF
--- a/route/include/route_generator_worker.h
+++ b/route/include/route_generator_worker.h
@@ -178,6 +178,9 @@ namespace route {
         double ll_crosstrack_distance_, ll_downtrack_distance_;
         unsigned int ll_id_;
 
+        // current speed limit on current lanelet
+        double speed_limit_ = 0;
+
         // local copy of Route publihsers
         ros::Publisher route_event_pub_, route_state_pub_, route_pub_;
 

--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -276,6 +276,28 @@ namespace route {
             ll_downtrack_distance_ = lanelet_track.downtrack;
             current_crosstrack_distance_ = track.crosstrack;
             current_downtrack_distance_ = track.downtrack;
+            // Determine speed limit
+            lanelet::Optional<carma_wm::TrafficRulesConstPtr> traffic_rules = world_model_->getTrafficRules();
+            
+            if (traffic_rules) 
+            {
+                auto laneletIterator = world_model_->getMap()->laneletLayer.find(ll_id_);
+                if (laneletIterator != laneletLayer.end()) {
+                    speed_limit_ = traffic_rules->speedLimit(*laneletIterator).speedLimit.value();
+                } 
+                else 
+                {
+                    ROS_ERROR_STREAM("Failed to set the current speed limit. The lanelet_id: "
+                        << ll_id_ << " could not be matched with a lanelet in the map. The previous speed limit of "
+                        << speed_limit_ << " will be used.");
+                }
+                
+            } 
+            else 
+            {
+                ROS_ERROR_STREAM("Failed to set the current speed limit. Valid traffic rules object could not be built.");
+            }
+
             // check if we left the seleted route by cross track error
             if(std::fabs(current_crosstrack_distance_) > cross_track_max_)
             {
@@ -327,6 +349,7 @@ namespace route {
             state_msg.down_track = current_downtrack_distance_;
             state_msg.lanelet_downtrack = ll_downtrack_distance_;
             state_msg.lanelet_id = ll_id_;
+            state_msg.speed_limit = speed_limit_;
             route_state_pub_.publish(state_msg);
         }
         // publish route event in order if any

--- a/route/src/route_generator_worker.cpp
+++ b/route/src/route_generator_worker.cpp
@@ -282,8 +282,8 @@ namespace route {
             if (traffic_rules) 
             {
                 auto laneletIterator = world_model_->getMap()->laneletLayer.find(ll_id_);
-                if (laneletIterator != laneletLayer.end()) {
-                    speed_limit_ = traffic_rules->speedLimit(*laneletIterator).speedLimit.value();
+                if (laneletIterator != world_model_->getMap()->laneletLayer.end()) {
+                    speed_limit_ = (*traffic_rules)->speedLimit(*laneletIterator).speedLimit.value();
                 } 
                 else 
                 {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR adds logic to set the speed limit of the current lanelet on the RouteState message. This can be used by the UI. 

I would have liked to add unit tests but the changes to world model to support that appear to not have been merged into this branch yet. They are probably still in Kyle's branch. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Supports #592 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Allow users to see speedlimit on ui
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
